### PR TITLE
Rename master branch to mainline

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -5,9 +5,9 @@ name: Python Flake8
 
 on:
   push:
-    branches: [ master ]
+    branches: [ mainline ]
   pull_request:
-    branches: [ master ]
+    branches: [ mainline ]
 
 jobs:
   build:


### PR DESCRIPTION
I've previously used the Github gui to rename the master branch to mainline, but this Github Actions file needs to be updated.