### PR TITLE
Specify branch in FetchSource stage of CodePipline

### DIFF
--- a/cdk/Pipeline.py
+++ b/cdk/Pipeline.py
@@ -25,6 +25,7 @@ class Pipeline(core.Stack):
         source_stage.add_action(aws_codepipeline_actions.GitHubSourceAction(
             oauth_token=oauth,
             output=source_output,
+            branch='mainline',
             owner='clemsonMakerspace',
             repo='unified-makerspace',
             action_name='GitHubSource'


### PR DESCRIPTION
The default branch for a GitHubSourceAction is 'master' so it is necessary to specify that we want to pull from mainline.﻿
