### PR TITLE
Add instructions on how to set up dev environment

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -80,3 +80,20 @@ The components of this system are described in [`makerspace.dot`](./makerspace.d
 ```
 dot makerspace.dot -Tpng > makerspace.png
 ```
+
+## Synthesizing the dev stack
+
+If you don't have an AWS account or haven't configured your workspace to create the dev stack (this might work automatically) then the only stack you'll see when synthesizing is the `Pipeline` stack, which works by creating a Beta and Prod stage and deploying the full makerspace stack.
+
+If dev stack setup worked for you automatically, then you can skip this next part. If it did not, then you can get it working with the following steps:
+
+1. Add your Clemson username to the `accounts_config` python module
+2. Set `USER=<you-username>` when synthesizing or deploying, for example:
+
+```
+USER=mhall6 cdk list
+```
+
+You'll need to have account permissions to the account you configure for your username.
+
+If you're trying to get an end-to-end example working in dev, you'll have to override the API URL and visit your cloudfront domains directly rather than, for example `beta-visit.cumaker.space` or `visit.cumaker.space`.


### PR DESCRIPTION
This is a small change to the README whose purpose is to show users how to set up dev stacks for the makerspace.

I split up the change here from the much bigger PR that created the dev stacks because I want to be sure those changes get shared with the team ASAP in case they have a chance to work on it.