### PR TITLE
[BUGFIX] Import causing build error in CodeBuild

### DIFF
--- a/cdk/app.py
+++ b/cdk/app.py
@@ -3,7 +3,6 @@
 import os
 
 from aws_cdk import core
-from maintenance_app.maintenance_app_stack import MaintenanceAppStack
 from Pipeline import Pipeline
 from accounts_config import accounts
 


### PR DESCRIPTION
I need to investigate why the build step fails in CodeBuild when it's running the exact same command `cdk synth` as I'm running locally with no issue. In the meanwhile, this line causes a stack trace in CodeBuild. Sorry for the PR churn.