### PR TITLE
[BUGFIX] Deploy the Pipeline stack to the correct account

### DIFF
--- a/cdk/app.py
+++ b/cdk/app.py
@@ -24,7 +24,7 @@ Also, all Pipeline-related resources go here, because we don't deploy
 those directly. Instead, we use the Pipline's self-mutation to update
 all the child stacks. So, everything beta/prod goes here.
 """
-pipeline = Pipeline(app, 'Pipeline', env=accounts['Prod'])
+pipeline = Pipeline(app, 'Pipeline', env=accounts['Beta'])
 
 
 """


### PR DESCRIPTION
We had previously decided to deploy the Pipeline to the Beta account, and
while it was done that way before, I (without thinking) changed it to Prod.
That caused the pipeline to deploy, but it can't actually run the self-mutate
step because I had this changed back locally and not committed to GitHub
where it can make the changes.

This reverts that mistake.