### PR TITLE
Retrieve domain information from attributes

### DIFF
--- a/cdk/makerspace.py
+++ b/cdk/makerspace.py
@@ -68,6 +68,8 @@ class MakerspaceStack(core.Stack):
 
         self.dns = MakerspaceDns(self.app, self.stage, env=self.env)
 
+        self.add_dependency(self.dns)
+
     def dns_records_stack(self):
 
         # Can only have cross-stack references in the same environment
@@ -81,3 +83,5 @@ class MakerspaceStack(core.Stack):
                                                 zones=self.dns,
                                                 api_gateway=self.api_gateway.api,
                                                 visit_distribution=self.visit.distribution)
+
+        self.add_dependency(self.dns_records)


### PR DESCRIPTION
Rather than passing the built value of the cloudfront distribution
and Route53 domains directly to the Route53 ARecord objects, this
change pulls in the references and re-constructs the values from
the referenced objects' attributes. The difference is that in the
background, CDK will pull in a special `Mapping` value,
`AWSCloudFrontPartitionHostedZoneIdMap`, which is required in order
to re-construct the zone id. That mapping exists in the stack that
creates the CloudFront distribution, but not in the stack that
references.

After this change, the required mapping exists in the correct
stack.

I also took the liberty to fix the dependency graph so that all
the stacks underneath MakerspaceStack will be dependencies of it.
Without this, things still worked, but logically this is the correct
organization, and it could prevent issues in the future