### PR TITLE
Updated Requirements.txt

### DIFF
--- a/cdk/requirements.txt
+++ b/cdk/requirements.txt
@@ -61,14 +61,14 @@ aws-cdk.cx-api==1.129.0
 aws-cdk.lambda-layer-awscli==1.129.0
 aws-cdk.pipelines==1.129.0
 aws-cdk.region-info==1.129.0
-awscli==1.18.179
-botocore==1.19.19
+botocore==1.24.0
 cattrs==1.8.0
 cffi==1.15.0
 colorama==0.4.3
 constructs==3.3.161
 cryptography==35.0.0
 docutils==0.15.2
+importlib-resources==5.4.0
 jmespath==0.10.0
 jsii==1.41.0
 publication==0.0.3
@@ -78,8 +78,9 @@ pycparser==2.20
 python-dateutil==2.8.2
 PyYAML==5.3.1
 rsa==4.5
-s3transfer==0.3.7
+s3transfer==0.5.1
 six==1.16.0
 toml==0.10.2
 typing-extensions==3.10.0.2
 urllib3==1.26.7
+zipp==3.7.0

--- a/cdk/requirements.txt
+++ b/cdk/requirements.txt
@@ -68,7 +68,6 @@ colorama==0.4.3
 constructs==3.3.161
 cryptography==35.0.0
 docutils==0.15.2
-importlib-resources==5.4.0
 jmespath==0.10.0
 jsii==1.41.0
 publication==0.0.3
@@ -83,4 +82,3 @@ six==1.16.0
 toml==0.10.2
 typing-extensions==3.10.0.2
 urllib3==1.26.7
-zipp==3.7.0


### PR DESCRIPTION
This PR will go ahead and remove the `awscli` dependency from `requirements.txt.` This was needed because the virtual environment version of the AWS CLI can override the installed binary.