### PR TITLE
Set lambda Access-Control-Origin to Environment Variables

### DIFF
--- a/cdk/visit/__init__.py
+++ b/cdk/visit/__init__.py
@@ -45,15 +45,15 @@ class Visit(core.Stack):
         self.source_bucket()
 
         # Retrieves the domain and its corresponding stage
-        self.domain_stage = self.zones.domains.visit
+        self.api_endpoint = self.zones.domains.visit
 
         # todo: restrict visitors page to require employee sign-in
         # self.cognito_pool()
 
         self.cloudfront_distribution()
 
-        self.log_visit_lambda(table_name, self.domain_stage)
-        self.register_user_lambda(table_name, self.domain_stage)
+        self.log_visit_lambda(table_name, self.api_endpoint)
+        self.register_user_lambda(table_name, self.api_endpoint)
 
     def source_bucket(self):
         self.oai = aws_cloudfront.OriginAccessIdentity(
@@ -102,7 +102,7 @@ class Visit(core.Stack):
         self.distribution = aws_cloudfront.Distribution(
             self, 'VisitorsConsoleCache', **kwargs)
 
-    def log_visit_lambda(self, table_name: str, domain_stage: str):
+    def log_visit_lambda(self, table_name: str, api_endpoint: str):
 
         sending_authorization_policy = aws_iam.PolicyStatement(
             effect=aws_iam.Effect.ALLOW)
@@ -116,14 +116,14 @@ class Visit(core.Stack):
             code=aws_lambda.Code.from_asset('visit/lambda_code'),
             environment={
                 'TABLE_NAME': table_name,
-                'DOMAIN_STAGE': domain_stage,
+                'API_ENDPOINT': api_endpoint,
             },
             handler='log_visit.handler',
             runtime=aws_lambda.Runtime.PYTHON_3_9)
 
         self.lambda_visit.role.add_to_policy(sending_authorization_policy)
 
-    def register_user_lambda(self, table_name: str, domain_stage: str):
+    def register_user_lambda(self, table_name: str, api_endpoint: str):
 
         self.lambda_register = aws_lambda.Function(
             self,
@@ -132,7 +132,7 @@ class Visit(core.Stack):
             code=aws_lambda.Code.from_asset('visit/lambda_code'),
             environment={
                 'TABLE_NAME': table_name,
-                'DOMAIN_STAGE': domain_stage,
+                'API_ENDPOINT': api_endpoint,
             },
             handler='register_user.handler',
             runtime=aws_lambda.Runtime.PYTHON_3_9)

--- a/cdk/visit/__init__.py
+++ b/cdk/visit/__init__.py
@@ -44,13 +44,16 @@ class Visit(core.Stack):
 
         self.source_bucket()
 
+        # Retrieves the domain and its corresponding stage
+        self.domain_stage = self.zones.domains.visit
+
         # todo: restrict visitors page to require employee sign-in
         # self.cognito_pool()
 
         self.cloudfront_distribution()
 
-        self.log_visit_lambda(table_name)
-        self.register_user_lambda(table_name)
+        self.log_visit_lambda(table_name, self.domain_stage)
+        self.register_user_lambda(table_name, self.domain_stage)
 
     def source_bucket(self):
         self.oai = aws_cloudfront.OriginAccessIdentity(
@@ -99,7 +102,7 @@ class Visit(core.Stack):
         self.distribution = aws_cloudfront.Distribution(
             self, 'VisitorsConsoleCache', **kwargs)
 
-    def log_visit_lambda(self, table_name: str):
+    def log_visit_lambda(self, table_name: str, domain_stage: str):
 
         sending_authorization_policy = aws_iam.PolicyStatement(
             effect=aws_iam.Effect.ALLOW)
@@ -113,13 +116,14 @@ class Visit(core.Stack):
             code=aws_lambda.Code.from_asset('visit/lambda_code'),
             environment={
                 'TABLE_NAME': table_name,
+                'DOMAIN_STAGE': domain_stage,
             },
             handler='log_visit.handler',
             runtime=aws_lambda.Runtime.PYTHON_3_9)
 
         self.lambda_visit.role.add_to_policy(sending_authorization_policy)
 
-    def register_user_lambda(self, table_name: str):
+    def register_user_lambda(self, table_name: str, domain_stage: str):
 
         self.lambda_register = aws_lambda.Function(
             self,
@@ -128,6 +132,7 @@ class Visit(core.Stack):
             code=aws_lambda.Code.from_asset('visit/lambda_code'),
             environment={
                 'TABLE_NAME': table_name,
+                'DOMAIN_STAGE': domain_stage,
             },
             handler='register_user.handler',
             runtime=aws_lambda.Runtime.PYTHON_3_9)

--- a/cdk/visit/__init__.py
+++ b/cdk/visit/__init__.py
@@ -44,16 +44,13 @@ class Visit(core.Stack):
 
         self.source_bucket()
 
-        # Retrieves the domain and its corresponding stage
-        self.api_endpoint = self.zones.domains.visit
-
         # todo: restrict visitors page to require employee sign-in
         # self.cognito_pool()
 
         self.cloudfront_distribution()
 
-        self.log_visit_lambda(table_name, self.api_endpoint)
-        self.register_user_lambda(table_name, self.api_endpoint)
+        self.log_visit_lambda(table_name)
+        self.register_user_lambda(table_name)
 
     def source_bucket(self):
         self.oai = aws_cloudfront.OriginAccessIdentity(
@@ -102,7 +99,7 @@ class Visit(core.Stack):
         self.distribution = aws_cloudfront.Distribution(
             self, 'VisitorsConsoleCache', **kwargs)
 
-    def log_visit_lambda(self, table_name: str, api_endpoint: str):
+    def log_visit_lambda(self, table_name: str):
 
         sending_authorization_policy = aws_iam.PolicyStatement(
             effect=aws_iam.Effect.ALLOW)
@@ -116,14 +113,14 @@ class Visit(core.Stack):
             code=aws_lambda.Code.from_asset('visit/lambda_code'),
             environment={
                 'TABLE_NAME': table_name,
-                'API_ENDPOINT': api_endpoint,
+                'API_ENDPOINT': self.distribution.domain_name,
             },
             handler='log_visit.handler',
             runtime=aws_lambda.Runtime.PYTHON_3_9)
 
         self.lambda_visit.role.add_to_policy(sending_authorization_policy)
 
-    def register_user_lambda(self, table_name: str, api_endpoint: str):
+    def register_user_lambda(self, table_name: str):
 
         self.lambda_register = aws_lambda.Function(
             self,
@@ -132,7 +129,7 @@ class Visit(core.Stack):
             code=aws_lambda.Code.from_asset('visit/lambda_code'),
             environment={
                 'TABLE_NAME': table_name,
-                'API_ENDPOINT': api_endpoint,
+                'API_ENDPOINT': self.distribution.domain_name,
             },
             handler='register_user.handler',
             runtime=aws_lambda.Runtime.PYTHON_3_9)

--- a/cdk/visit/lambda_code/log_visit.py
+++ b/cdk/visit/lambda_code/log_visit.py
@@ -17,6 +17,7 @@ logger.setLevel(logging.INFO)
 dynamodb = boto3.resource('dynamodb')
 # Get the table name.
 TABLE_NAME = os.environ["TABLE_NAME"]
+# Get the appropriate domain variable
 DOMAIN_STAGE = os.environ["DOMAIN_STAGE"]
 # Get table objects
 visits = dynamodb.Table(TABLE_NAME)

--- a/cdk/visit/lambda_code/log_visit.py
+++ b/cdk/visit/lambda_code/log_visit.py
@@ -18,7 +18,7 @@ dynamodb = boto3.resource('dynamodb')
 # Get the table name.
 TABLE_NAME = os.environ["TABLE_NAME"]
 # Get the appropriate domain variable
-DOMAIN_STAGE = os.environ["DOMAIN_STAGE"]
+API_ENDPOINT = os.environ["API_ENDPOINT"]
 # Get table objects
 visits = dynamodb.Table(TABLE_NAME)
 
@@ -126,7 +126,7 @@ def handler(request, context):
     HEADERS = {
         'Content-Type': 'application/json',
         'Access-Control-Allow-Headers': 'Content-Type',
-        'Access-Control-Allow-Origin': DOMAIN_STAGE,
+        'Access-Control-Allow-Origin': API_ENDPOINT,
         'Access-Control-Allow-Methods': 'OPTIONS,POST,GET'
     }
 

--- a/cdk/visit/lambda_code/log_visit.py
+++ b/cdk/visit/lambda_code/log_visit.py
@@ -17,6 +17,7 @@ logger.setLevel(logging.INFO)
 dynamodb = boto3.resource('dynamodb')
 # Get the table name.
 TABLE_NAME = os.environ["TABLE_NAME"]
+DOMAIN_STAGE = os.environ["DOMAIN_STAGE"]
 # Get table objects
 visits = dynamodb.Table(TABLE_NAME)
 
@@ -124,7 +125,7 @@ def handler(request, context):
     HEADERS = {
         'Content-Type': 'application/json',
         'Access-Control-Allow-Headers': 'Content-Type',
-        'Access-Control-Allow-Origin': 'https://visit.cumaker.space',
+        'Access-Control-Allow-Origin': DOMAIN_STAGE,
         'Access-Control-Allow-Methods': 'OPTIONS,POST,GET'
     }
 

--- a/cdk/visit/lambda_code/register_user.py
+++ b/cdk/visit/lambda_code/register_user.py
@@ -8,6 +8,7 @@ import datetime
 dynamodb = boto3.resource('dynamodb')
 # Get the table name.
 TABLE_NAME = os.environ["TABLE_NAME"]
+DOMAIN_STAGE = os.environ["DOMAIN_STAGE"]
 # Get table objects
 users = dynamodb.Table(TABLE_NAME)
 
@@ -40,7 +41,7 @@ def handler(request, context):
     HEADERS = {
         'Content-Type': 'application/json',
         'Access-Control-Allow-Headers': 'Content-Type',
-        'Access-Control-Allow-Origin': 'https://visit.cumaker.space',
+        'Access-Control-Allow-Origin': DOMAIN_STAGE,
         'Access-Control-Allow-Methods': 'OPTIONS,POST,GET'
     }
     if (request is None):

--- a/cdk/visit/lambda_code/register_user.py
+++ b/cdk/visit/lambda_code/register_user.py
@@ -9,7 +9,7 @@ dynamodb = boto3.resource('dynamodb')
 # Get the table name.
 TABLE_NAME = os.environ["TABLE_NAME"]
 # Get the appropriate domain variable
-DOMAIN_STAGE = os.environ["DOMAIN_STAGE"]
+API_ENDPOINT = os.environ["API_ENDPOINT"]
 # Get table objects
 users = dynamodb.Table(TABLE_NAME)
 
@@ -42,7 +42,7 @@ def handler(request, context):
     HEADERS = {
         'Content-Type': 'application/json',
         'Access-Control-Allow-Headers': 'Content-Type',
-        'Access-Control-Allow-Origin': DOMAIN_STAGE,
+        'Access-Control-Allow-Origin': API_ENDPOINT,
         'Access-Control-Allow-Methods': 'OPTIONS,POST,GET'
     }
     if (request is None):

--- a/cdk/visit/lambda_code/register_user.py
+++ b/cdk/visit/lambda_code/register_user.py
@@ -8,6 +8,7 @@ import datetime
 dynamodb = boto3.resource('dynamodb')
 # Get the table name.
 TABLE_NAME = os.environ["TABLE_NAME"]
+# Get the appropriate domain variable
 DOMAIN_STAGE = os.environ["DOMAIN_STAGE"]
 # Get table objects
 users = dynamodb.Table(TABLE_NAME)


### PR DESCRIPTION
-Pass in a new environment variable to the visit lambda functions, the environment variable is the domain with the appropriate stage included that should make it easier to have the lambda functions work in any stage
-The new environment variables show up in the AWS console, and are labeled as DOMAIN_STAGE, and the value should be the appropriate domain, in my case it showed as "dev-visit.cumaker.space"
-Tests were ran on the lambda functions as well, and everything worked as intended.
