### PR TITLE
Split Dynamo DB into multiple tables

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,4 +25,6 @@ jobs:
               env:
                   AWS_DEFAULT_REGION: us-east-1
                   AWS_REGION: us-east-1
-                  TABLE_NAME: visits
+                  VISITS_TABLE_NAME: visits
+                  ORIGINAL_TABLE_NAME: original
+                  USERS_TABLE_NAME: users

--- a/cdk/database/__init__.py
+++ b/cdk/database/__init__.py
@@ -73,10 +73,10 @@ class Database(core.Stack):
                                                self.visits_id,
                                                point_in_time_recovery=True,
                                                removal_policy=core.RemovalPolicy.RETAIN,
-                                               sort_key=aws_dynamodb.Attribute(
+                                               partition_key=aws_dynamodb.Attribute(
                                                    name='username',
                                                    type=aws_dynamodb.AttributeType.STRING),
-                                               partition_key=aws_dynamodb.Attribute(
+                                               sort_key=aws_dynamodb.Attribute(
                                                    name='visit_time',
                                                    type=aws_dynamodb.AttributeType.STRING))
 
@@ -85,9 +85,6 @@ class Database(core.Stack):
                                               self.users_id,
                                               point_in_time_recovery=True,
                                               removal_policy=core.RemovalPolicy.RETAIN,
-                                              sort_key=aws_dynamodb.Attribute(
-                                                  name='last_name',
-                                                  type=aws_dynamodb.AttributeType.STRING),
                                               partition_key=aws_dynamodb.Attribute(
                                                   name='username',
                                                   type=aws_dynamodb.AttributeType.STRING))

--- a/cdk/database/__init__.py
+++ b/cdk/database/__init__.py
@@ -78,7 +78,7 @@ class Database(core.Stack):
                                                    type=aws_dynamodb.AttributeType.STRING),
                                                partition_key=aws_dynamodb.Attribute(
                                                    name='visit_time',
-                                                   type=aws_dynamodb.AttributeType.NUMBER))
+                                                   type=aws_dynamodb.AttributeType.STRING))
 
     def dynamodb_users_table(self):
         self.users_table = aws_dynamodb.Table(self,

--- a/cdk/database/__init__.py
+++ b/cdk/database/__init__.py
@@ -8,11 +8,13 @@ from aws_cdk import (
 class Database(core.Stack):
     def __init__(self, scope: core.Construct,
                  stage: str, *, env: core.Environment):
+        self.id = f'Database-{stage}'
         self.users_id = f'-users-{stage}'
         self.visits_id = f'-visits-{stage}'
         super().__init__(
             scope, f'Database-{stage}', env=env, termination_protection=True)
 
+        self.dynamodb_single_table()  # This is the original table.
         self.dynamodb_visits_table()
         self.dynamodb_users_table()
 

--- a/cdk/makerspace.py
+++ b/cdk/makerspace.py
@@ -38,8 +38,9 @@ class MakerspaceStack(core.Stack):
 
         self.visitors_stack()
 
-        self.database.table.grant_read_write_data(self.visit.lambda_visit)
-        self.database.table.grant_write_data(self.visit.lambda_register)
+        self.database.visits_table.grant_read_write_data(
+            self.visit.lambda_visit)
+        self.database.users_table.grant_write_data(self.visit.lambda_register)
 
         self.shared_api_gateway()
 
@@ -57,7 +58,8 @@ class MakerspaceStack(core.Stack):
         self.visit = Visit(
             self.app,
             self.stage,
-            self.database.table.table_name,
+            self.database.visits_table.table_name,
+            self.database.users_table.table_name,
             create_dns=self.create_dns,
             zones=self.dns,
             env=self.env)

--- a/cdk/makerspace.py
+++ b/cdk/makerspace.py
@@ -40,7 +40,9 @@ class MakerspaceStack(core.Stack):
 
         self.database.visits_table.grant_read_write_data(
             self.visit.lambda_visit)
-        self.database.users_table.grant_write_data(self.visit.lambda_register)
+        self.database.users_table.grant_read_data(self.visit.lambda_visit)
+        self.database.users_table.grant_read_write_data(
+            self.visit.lambda_register)
 
         self.shared_api_gateway()
 

--- a/cdk/makerspace.py
+++ b/cdk/makerspace.py
@@ -38,6 +38,10 @@ class MakerspaceStack(core.Stack):
 
         self.visitors_stack()
 
+        # Accomodating the original database to mitigate transition issues.
+        self.database.table.grant_read_write_data(self.visit.lambda_visit)
+        self.database.table.grant_read_data(self.visit.lambda_register)
+
         self.database.visits_table.grant_read_write_data(
             self.visit.lambda_visit)
         self.database.users_table.grant_read_data(self.visit.lambda_visit)
@@ -62,6 +66,7 @@ class MakerspaceStack(core.Stack):
             self.stage,
             self.database.visits_table.table_name,
             self.database.users_table.table_name,
+            self.database.table.table_name,
             create_dns=self.create_dns,
             zones=self.dns,
             env=self.env)

--- a/cdk/visit/__init__.py
+++ b/cdk/visit/__init__.py
@@ -50,7 +50,7 @@ class Visit(core.Stack):
 
         self.cloudfront_distribution()
 
-        self.log_visit_lambda(visits_table_name)
+        self.log_visit_lambda(visits_table_name, users_table_name)
         self.register_user_lambda(users_table_name)
 
     def source_bucket(self):
@@ -100,7 +100,7 @@ class Visit(core.Stack):
         self.distribution = aws_cloudfront.Distribution(
             self, 'VisitorsConsoleCache', **kwargs)
 
-    def log_visit_lambda(self, table_name: str):
+    def log_visit_lambda(self, visits_table_name: str, users_table_name: str):
 
         sending_authorization_policy = aws_iam.PolicyStatement(
             effect=aws_iam.Effect.ALLOW)
@@ -113,7 +113,9 @@ class Visit(core.Stack):
             function_name=core.PhysicalName.GENERATE_IF_NEEDED,
             code=aws_lambda.Code.from_asset('visit/lambda_code/log_visit'),
             environment={
-                'TABLE_NAME': table_name,
+                'TABLE_NAME': visits_table_name,
+                'VISITS_TABLE_NAME': visits_table_name,
+                'USERS_TABLE_NAME': users_table_name
             },
             handler='log_visit.handler',
             runtime=aws_lambda.Runtime.PYTHON_3_9)

--- a/cdk/visit/__init__.py
+++ b/cdk/visit/__init__.py
@@ -31,7 +31,8 @@ class Visit(core.Stack):
 
     def __init__(self, scope: core.Construct,
                  stage: str,
-                 table_name: str,
+                 visits_table_name: str,
+                 users_table_name: str,
                  *,
                  env: core.Environment,
                  create_dns: bool,
@@ -49,8 +50,8 @@ class Visit(core.Stack):
 
         self.cloudfront_distribution()
 
-        self.log_visit_lambda(table_name)
-        self.register_user_lambda(table_name)
+        self.log_visit_lambda(visits_table_name)
+        self.register_user_lambda(users_table_name)
 
     def source_bucket(self):
         self.oai = aws_cloudfront.OriginAccessIdentity(

--- a/cdk/visit/lambda_code/log_visit/log_visit.py
+++ b/cdk/visit/lambda_code/log_visit/log_visit.py
@@ -118,7 +118,7 @@ class LogVisitFunction():
             # SK = Sort Key = Username or Email Address
 
             Item={
-                'visit_time': str(visit_date),
+                'visit_time': int(visit_date),
                 'username': current_user,
                 'location': location,
             },
@@ -200,7 +200,7 @@ class LogVisitFunction():
             }
 
 
-log_visit_function = LogVisitFunction(None, None)
+log_visit_function = LogVisitFunction(None, None, None)
 
 
 def handler(request, context):

--- a/cdk/visit/lambda_code/log_visit/log_visit.py
+++ b/cdk/visit/lambda_code/log_visit/log_visit.py
@@ -26,7 +26,7 @@ class LogVisitFunction():
         # Get the service resource.
         dynamodb = boto3.resource('dynamodb')
         # Get the table name.
-        ORIGINAL_TABLE_NAME = os.environ["VISITS_TABLE_NAME"]
+        ORIGINAL_TABLE_NAME = os.environ["ORIGINAL_TABLE_NAME"]
         # Get table objects
         self.original_table = dynamodb.Table(ORIGINAL_TABLE_NAME)
 

--- a/cdk/visit/lambda_code/log_visit/log_visit.py
+++ b/cdk/visit/lambda_code/log_visit/log_visit.py
@@ -17,19 +17,29 @@ class LogVisitFunction():
     so we can more easily test with pytest.
     """
 
-    def __init__(self, table, ses_client):
+    def __init__(self, visits_table, users_table, ses_client):
         self.logger = logging.getLogger()
         self.logger.setLevel(logging.INFO)
 
-        if table is None:
+        if visits_table is None:
             # Get the service resource.
             dynamodb = boto3.resource('dynamodb')
             # Get the table name.
-            TABLE_NAME = os.environ["TABLE_NAME"]
+            VISITS_TABLE_NAME = os.environ["VISITS_TABLE_NAME"]
             # Get table objects
-            self.visits = dynamodb.Table(TABLE_NAME)
+            self.visits = dynamodb.Table(VISITS_TABLE_NAME)
         else:
-            self.visits = table
+            self.visits = visits_table
+
+        if users_table is None:
+            # Get the service resource.
+            dynamodb = boto3.resource('dynamodb')
+            # Get the table name.
+            USERS_TABLE_NAME = os.environ["USERS_TABLE_NAME"]
+            # Get table objects
+            self.users = dynamodb.Table(USERS_TABLE_NAME)
+        else:
+            self.users = users_table
 
         if ses_client is None:
             AWS_REGION = os.environ['AWS_REGION']
@@ -38,8 +48,8 @@ class LogVisitFunction():
             self.client = ses_client
 
     def checkRegistration(self, current_user):
-        response = self.visits.query(
-            KeyConditionExpression=Key('PK').eq(current_user)
+        response = self.users.query(
+            KeyConditionExpression=Key('username').eq(current_user)
         )
         return response['Count']
 
@@ -108,8 +118,8 @@ class LogVisitFunction():
             # SK = Sort Key = Username or Email Address
 
             Item={
-                'PK': str(visit_date),
-                'SK': current_user,
+                'visit_time': str(visit_date),
+                'username': current_user,
                 'location': location,
             },
         )

--- a/cdk/visit/lambda_code/log_visit/log_visit.py
+++ b/cdk/visit/lambda_code/log_visit/log_visit.py
@@ -17,18 +17,21 @@ class LogVisitFunction():
     so we can more easily test with pytest.
     """
 
-    def __init__(self, visits_table, users_table, ses_client, pytest=False):
+    def __init__(self, visits_table, users_table, original_table, ses_client, pytest=False):
         self.logger = logging.getLogger()
         self.logger.setLevel(logging.INFO)
 
         self.pytest = pytest
 
-        # Get the service resource.
-        dynamodb = boto3.resource('dynamodb')
-        # Get the table name.
-        ORIGINAL_TABLE_NAME = os.environ["ORIGINAL_TABLE_NAME"]
-        # Get table objects
-        self.original_table = dynamodb.Table(ORIGINAL_TABLE_NAME)
+        if original_table is not None:
+            # Get the service resource.
+            dynamodb = boto3.resource('dynamodb')
+            # Get the table name.
+            ORIGINAL_TABLE_NAME = os.environ["ORIGINAL_TABLE_NAME"]
+            # Get table objects
+            self.original_table = dynamodb.Table(ORIGINAL_TABLE_NAME)
+        else:
+            self.original_table = original_table
 
         if visits_table is None:
             # Get the service resource.
@@ -57,10 +60,10 @@ class LogVisitFunction():
             self.client = ses_client
 
     def checkRegistration(self, current_user):
+        print("Checking registration for: " + current_user)
         users_table_response = self.users.query(
             KeyConditionExpression=Key('username').eq(current_user)
         )
-
         # We are in prod. Check the OG table too.
         original_table_response = self.original_table.query(
             KeyConditionExpression=Key('PK').eq(current_user)
@@ -220,7 +223,7 @@ class LogVisitFunction():
             }
 
 
-log_visit_function = LogVisitFunction(None, None, None)
+log_visit_function = LogVisitFunction(None, None, None, None)
 
 
 def handler(request, context):

--- a/cdk/visit/lambda_code/log_visit/log_visit.py
+++ b/cdk/visit/lambda_code/log_visit/log_visit.py
@@ -128,6 +128,9 @@ class LogVisitFunction():
     def addVisitEntry(self, current_user, location):
         # Get the current date at which the user logs in.
         visit_date = datetime.datetime.now().timestamp()
+        # Convert visit_date to human-readable format
+        visit_date = datetime.datetime.fromtimestamp(
+            visit_date).strftime('%Y-%m-%d %H:%M:%S')
 
         # Add the item to the table.
         response = self.visits.put_item(
@@ -135,7 +138,7 @@ class LogVisitFunction():
             # SK = Sort Key = Username or Email Address
 
             Item={
-                'visit_time': int(visit_date),
+                'visit_time': str(visit_date),
                 'username': current_user,
                 'location': location,
             },

--- a/cdk/visit/lambda_code/register_user/register_user.py
+++ b/cdk/visit/lambda_code/register_user/register_user.py
@@ -21,7 +21,7 @@ class RegisterUserFunction():
             # Get the service resource.
             dynamodb = boto3.resource('dynamodb')
             # Get the table name.
-            TABLE_NAME = os.environ["TABLE_NAME"]
+            TABLE_NAME = os.environ["USERS_TABLE_NAME"]
             # Get table objects
             self.users = dynamodb.Table(TABLE_NAME)
         else:

--- a/cdk/visit/lambda_code/register_user/register_user.py
+++ b/cdk/visit/lambda_code/register_user/register_user.py
@@ -33,7 +33,7 @@ class RegisterUserFunction():
 
         response = self.users.put_item(
             Item={
-                'username': user_info['username'],
+                'username': user_info['username'].lower(),
                 'register_time': str(timestamp),
                 'first_name': user_info['first_name'],
                 'last_name': user_info['last_name'],

--- a/cdk/visit/lambda_code/register_user/register_user.py
+++ b/cdk/visit/lambda_code/register_user/register_user.py
@@ -27,7 +27,7 @@ class RegisterUserFunction():
         else:
             self.users = table
 
-    def addUserInfo(self, user_info):
+    def add_user_info(self, user_info):
         # Get the current date at which the user registers.
         timestamp = datetime.datetime.now()
 
@@ -35,13 +35,13 @@ class RegisterUserFunction():
             Item={
                 'username': user_info['username'],
                 'register_time': str(timestamp),
-                'first_name': user_info['firstName'],
-                'last_name': user_info['lastName'],
-                'gender': user_info['Gender'],
-                'date_of_birth': user_info['DOB'],
-                'grad_date': user_info['Grad_Date'],
-                'major': user_info['Major'],
-                'minor': user_info['Minor']
+                'first_name': user_info['first_name'],
+                'last_name': user_info['last_name'],
+                'gender': user_info['gender'],
+                'date_of_birth': user_info['date_of_birth'],
+                'grad_date': user_info['grad_date'],
+                'major': user_info['major'],
+                'minor': user_info['minor']
             },
         )
 
@@ -66,7 +66,7 @@ class RegisterUserFunction():
         # Get all of the user information from the json file
         user_info = json.loads(request["body"])
         # Call Function
-        response = self.addUserInfo(user_info)
+        response = self.add_user_info(user_info)
         # Send response
         return {
             'headers': HEADERS,

--- a/cdk/visit/lambda_code/register_user/register_user.py
+++ b/cdk/visit/lambda_code/register_user/register_user.py
@@ -33,15 +33,15 @@ class RegisterUserFunction():
 
         response = self.users.put_item(
             Item={
-                'PK': user_info['username'],
-                'SK': str(timestamp),
-                'firstName': user_info['firstName'],
-                'lastName': user_info['lastName'],
-                'Gender': user_info['Gender'],
-                'DOB': user_info['DOB'],
-                'Grad_date': user_info['Grad_Date'],
-                'Major': user_info['Major'],
-                'Minor': user_info['Minor']
+                'username': user_info['username'],
+                'register_time': str(timestamp),
+                'first_name': user_info['firstName'],
+                'last_name': user_info['lastName'],
+                'gender': user_info['Gender'],
+                'date_of_birth': user_info['DOB'],
+                'grad_date': user_info['Grad_Date'],
+                'major': user_info['Major'],
+                'minor': user_info['Minor']
             },
         )
 

--- a/cdk/visit/lambda_code/test_log_visit.py
+++ b/cdk/visit/lambda_code/test_log_visit.py
@@ -103,6 +103,58 @@ def create_test_visit_table():
     return table
 
 
+def create_test_original_table():
+    """
+    Create a dynamodb table for testing
+
+    Returns:
+        dynamodb.Table: A dynamodb table
+
+    """
+    table_name = 'original'
+    dymanodb = boto3.resource('dynamodb', 'us-east-1')
+
+    table = dymanodb.create_table(
+        TableName=table_name,
+        KeySchema=[
+            {
+                'AttributeName': 'PK',
+                'KeyType': 'HASH'  # Partition key
+            },
+            {
+                'AttributeName': 'SK',
+                'KeyType': 'RANGE'  # Sort key
+            },
+            {
+                'AttributeName': 'location',
+                'KeyType': 'RANGE'
+            }
+        ],
+        AttributeDefinitions=[
+            {
+                'AttributeName': 'PK',
+                'AttributeType': 'S'
+            },
+            {
+                'AttributeName': 'SK',
+                'AttributeType': 'S'
+            },
+            {
+                'AttributeName': 'location',
+                'AttributeType': 'S'
+            }
+        ],
+        ProvisionedThroughput={
+            'ReadCapacityUnits': 5,
+            'WriteCapacityUnits': 5
+        }
+    )
+
+    table.wait_until_exists()
+
+    return table
+
+
 def create_ses_client():
     client = boto3.client('ses', region_name='us-east-1')
 
@@ -114,11 +166,11 @@ def create_ses_client():
 def test_visit_with_location():
     visits_table = create_test_visit_table()
     users_table = create_test_users_table()
+    original_table = create_test_original_table()
     client = create_ses_client()
 
-    response = LogVisitFunction(visits_table, users_table, client).handle_log_visit_request(
+    response = LogVisitFunction(visits_table, users_table, original_table, client).handle_log_visit_request(
         test_log_visit_with_location, None)
-
     assert response['statusCode'] == 200
 
 
@@ -126,6 +178,7 @@ def test_visit_with_location():
 def test_visit_with_no_location():
     visits_table = create_test_visit_table()
     users_table = create_test_users_table()
-    response = LogVisitFunction(visits_table, users_table, None).handle_log_visit_request(
+    original_table = create_test_original_table()
+    response = LogVisitFunction(visits_table, users_table, original_table, None).handle_log_visit_request(
         test_log_visit_with_no_location, None)
     assert response['statusCode'] == 200

--- a/cdk/visit/lambda_code/test_log_visit.py
+++ b/cdk/visit/lambda_code/test_log_visit.py
@@ -81,7 +81,7 @@ def create_test_visit_table():
         AttributeDefinitions=[
             {
                 'AttributeName': 'visit_time',
-                'AttributeType': 'N'
+                'AttributeType': 'S'
             },
             {
                 'AttributeName': 'username',

--- a/cdk/visit/lambda_code/test_register_user.py
+++ b/cdk/visit/lambda_code/test_register_user.py
@@ -9,13 +9,13 @@ from moto import mock_dynamodb2
 
 test_register_user = {"body": json.dumps({
     "username": "jmdanie234",
-    "firstName": "John",
-    "lastName": "Doe",
-    "Gender": "Male",
-    "DOB": "01/02/2002",
-    "Grad_Date": "05/01/2023",
-    "Major": "Mathematical Sciences",
-    "Minor": "Business Administration"
+    "first_name": "John",
+    "last_name": "Doe",
+    "gender": "Male",
+    "date_of_birth": "01/02/2002",
+    "grad_date": "05/01/2023",
+    "major": "Mathematical Sciences",
+    "minor": "Business Administration"
 })}
 
 
@@ -27,21 +27,21 @@ def create_dynamodb_table():
         TableName=table_name,
         KeySchema=[
             {
-                'AttributeName': 'PK',
+                'AttributeName': 'username',
                 'KeyType': 'HASH'  # Partition key
             },
             {
-                'AttributeName': 'SK',
+                'AttributeName': 'last_name',
                 'KeyType': 'RANGE'  # Sort key
             },
         ],
         AttributeDefinitions=[
             {
-                'AttributeName': 'PK',
+                'AttributeName': 'username',
                 'AttributeType': 'S'
             },
             {
-                'AttributeName': 'SK',
+                'AttributeName': 'last_name',
                 'AttributeType': 'S'
             },
         ],


### PR DESCRIPTION
# Summary

This PR will create 2 new tables in DynamoDB. One table will track visits, while the other will track registrations. When this is merged, all writes to the original table will cease, with reads only occurring for registration checking. Meanwhile, we will write all visits and registrations to the new tables.