### PR TITLE
Revert "Set lambda Access-Control-Origin to Environment Variables"

### DIFF
--- a/cdk/visit/__init__.py
+++ b/cdk/visit/__init__.py
@@ -113,7 +113,6 @@ class Visit(core.Stack):
             code=aws_lambda.Code.from_asset('visit/lambda_code'),
             environment={
                 'TABLE_NAME': table_name,
-                'API_ENDPOINT': self.distribution.domain_name,
             },
             handler='log_visit.handler',
             runtime=aws_lambda.Runtime.PYTHON_3_9)
@@ -129,7 +128,6 @@ class Visit(core.Stack):
             code=aws_lambda.Code.from_asset('visit/lambda_code'),
             environment={
                 'TABLE_NAME': table_name,
-                'API_ENDPOINT': self.distribution.domain_name,
             },
             handler='register_user.handler',
             runtime=aws_lambda.Runtime.PYTHON_3_9)

--- a/cdk/visit/lambda_code/log_visit.py
+++ b/cdk/visit/lambda_code/log_visit.py
@@ -17,8 +17,6 @@ logger.setLevel(logging.INFO)
 dynamodb = boto3.resource('dynamodb')
 # Get the table name.
 TABLE_NAME = os.environ["TABLE_NAME"]
-# Get the appropriate domain variable
-API_ENDPOINT = os.environ["API_ENDPOINT"]
 # Get table objects
 visits = dynamodb.Table(TABLE_NAME)
 
@@ -126,7 +124,7 @@ def handler(request, context):
     HEADERS = {
         'Content-Type': 'application/json',
         'Access-Control-Allow-Headers': 'Content-Type',
-        'Access-Control-Allow-Origin': API_ENDPOINT,
+        'Access-Control-Allow-Origin': 'https://visit.cumaker.space',
         'Access-Control-Allow-Methods': 'OPTIONS,POST,GET'
     }
 

--- a/cdk/visit/lambda_code/register_user.py
+++ b/cdk/visit/lambda_code/register_user.py
@@ -8,8 +8,6 @@ import datetime
 dynamodb = boto3.resource('dynamodb')
 # Get the table name.
 TABLE_NAME = os.environ["TABLE_NAME"]
-# Get the appropriate domain variable
-API_ENDPOINT = os.environ["API_ENDPOINT"]
 # Get table objects
 users = dynamodb.Table(TABLE_NAME)
 
@@ -42,7 +40,7 @@ def handler(request, context):
     HEADERS = {
         'Content-Type': 'application/json',
         'Access-Control-Allow-Headers': 'Content-Type',
-        'Access-Control-Allow-Origin': API_ENDPOINT,
+        'Access-Control-Allow-Origin': 'https://visit.cumaker.space',
         'Access-Control-Allow-Methods': 'OPTIONS,POST,GET'
     }
     if (request is None):


### PR DESCRIPTION
Reverts clemsonMakerspace/unified-makerspace#77

This put the cloudfront domain as the lambda's API endpoint env var, not the API endpoint. Will need to revisit where we are pulling this value from

<img width="866" alt="Screen Shot 2022-03-14 at 12 20 56 AM" src="https://user-images.githubusercontent.com/54962363/158105289-8d1b54df-477f-4184-b653-fb819159a7f1.png">

