### PR TITLE
Fix Pytest Action by Moving Environment Variables

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,3 +24,5 @@ jobs:
               run: pytest cdk/visit/lambda_code
               env:
                   AWS_DEFAULT_REGION: us-east-1
+                  AWS_REGION: us-east-1
+                  TABLE_NAME: visits

--- a/cdk/visit/lambda_code/test_log_visit.py
+++ b/cdk/visit/lambda_code/test_log_visit.py
@@ -4,10 +4,6 @@ import boto3
 import pytest
 import os
 
-# This has to run after we set the environment variables
-# so we don't break pytest.
-
-
 test_log_visit_with_no_location = {
     "body": "{\"username\":\"jmdanie234\"}"
 }

--- a/cdk/visit/lambda_code/test_log_visit.py
+++ b/cdk/visit/lambda_code/test_log_visit.py
@@ -4,9 +4,6 @@ import boto3
 import pytest
 import os
 
-os.environ["TABLE_NAME"] = "visits"
-os.environ["AWS_REGION"] = "us-east-1"
-
 # This has to run after we set the environment variables
 # so we don't break pytest.
 

--- a/cdk/visit/lambda_code/test_register_user.py
+++ b/cdk/visit/lambda_code/test_register_user.py
@@ -6,8 +6,6 @@ import json
 import boto3
 from moto import mock_dynamodb2
 
-os.environ["TABLE_NAME"] = "users"
-
 # This needs to happen after we set the environment variable so
 # the cold start code doesn't break pytest.
 

--- a/cdk/visit/lambda_code/test_register_user.py
+++ b/cdk/visit/lambda_code/test_register_user.py
@@ -6,9 +6,6 @@ import json
 import boto3
 from moto import mock_dynamodb2
 
-# This needs to happen after we set the environment variable so
-# the cold start code doesn't break pytest.
-
 
 test_register_user = {"body": json.dumps({
     "username": "jmdanie234",


### PR DESCRIPTION
I moved the environment variables in the Pytest scripts to the Github action. This allows the pytest cases to run without needing to do any weird formatting.