### PR TITLE
Modified CORS header origin variable

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,3 +26,4 @@ jobs:
                   AWS_DEFAULT_REGION: us-east-1
                   AWS_REGION: us-east-1
                   TABLE_NAME: visits
+                  DOMAIN_NAME: https://visit.cumaker.space

--- a/cdk/visit/__init__.py
+++ b/cdk/visit/__init__.py
@@ -49,8 +49,10 @@ class Visit(core.Stack):
 
         self.cloudfront_distribution()
 
-        self.log_visit_lambda(table_name)
-        self.register_user_lambda(table_name)
+        self.domain_name = self.distribution.domain_name if stage == 'Dev' else self.zones.visit.zone_name
+
+        self.log_visit_lambda(table_name, ("https://" + self.domain_name))
+        self.register_user_lambda(table_name, ("https://" + self.domain_name))
 
     def source_bucket(self):
         self.oai = aws_cloudfront.OriginAccessIdentity(
@@ -99,7 +101,7 @@ class Visit(core.Stack):
         self.distribution = aws_cloudfront.Distribution(
             self, 'VisitorsConsoleCache', **kwargs)
 
-    def log_visit_lambda(self, table_name: str):
+    def log_visit_lambda(self, table_name: str, domain_name: str):
 
         sending_authorization_policy = aws_iam.PolicyStatement(
             effect=aws_iam.Effect.ALLOW)
@@ -113,13 +115,14 @@ class Visit(core.Stack):
             code=aws_lambda.Code.from_asset('visit/lambda_code/log_visit'),
             environment={
                 'TABLE_NAME': table_name,
+                'DOMAIN_NAME': domain_name,
             },
             handler='log_visit.handler',
             runtime=aws_lambda.Runtime.PYTHON_3_9)
 
         self.lambda_visit.role.add_to_policy(sending_authorization_policy)
 
-    def register_user_lambda(self, table_name: str):
+    def register_user_lambda(self, table_name: str, domain_name: str):
 
         self.lambda_register = aws_lambda.Function(
             self,
@@ -128,6 +131,7 @@ class Visit(core.Stack):
             code=aws_lambda.Code.from_asset('visit/lambda_code/register_user'),
             environment={
                 'TABLE_NAME': table_name,
+                'DOMAIN_NAME': domain_name,
             },
             handler='register_user.handler',
             runtime=aws_lambda.Runtime.PYTHON_3_9)

--- a/cdk/visit/lambda_code/log_visit/log_visit.py
+++ b/cdk/visit/lambda_code/log_visit/log_visit.py
@@ -130,7 +130,7 @@ class LogVisitFunction():
         HEADERS = {
             'Content-Type': 'application/json',
             'Access-Control-Allow-Headers': 'Content-Type',
-            'Access-Control-Allow-Origin': 'https://visit.cumaker.space',
+            'Access-Control-Allow-Origin': os.environ["DOMAIN_NAME"],
             'Access-Control-Allow-Methods': 'OPTIONS,POST,GET'
         }
 

--- a/cdk/visit/lambda_code/register_user/register_user.py
+++ b/cdk/visit/lambda_code/register_user/register_user.py
@@ -51,7 +51,7 @@ class RegisterUserFunction():
         HEADERS = {
             'Content-Type': 'application/json',
             'Access-Control-Allow-Headers': 'Content-Type',
-            'Access-Control-Allow-Origin': 'https://visit.cumaker.space',
+            'Access-Control-Allow-Origin': os.environ["DOMAIN_NAME"],
             'Access-Control-Allow-Methods': 'OPTIONS,POST,GET'
         }
         if (request is None):


### PR DESCRIPTION
Modified the access-allow-control-origin CORS variable so that:

- Testing on the dev stack will set the primary cloudfront domain, generated by AWS, as the origin
- The production and beta stages will use the alternate domain (https://beta-visit.cumaker.space, https://visit.cumaker.space)
