### PR TITLE
Fix the storage of Major and Minor lists in the database

### DIFF
--- a/cdk/visit/lambda_code/register_user/register_user.py
+++ b/cdk/visit/lambda_code/register_user/register_user.py
@@ -40,8 +40,8 @@ class RegisterUserFunction():
                 'Gender': user_info['Gender'],
                 'DOB': user_info['DOB'],
                 'Grad_date': user_info['Grad_Date'],
-                'Major': user_info['Major'],
-                'Minor': user_info.get('Minor', [])
+                'Major': ', '.join(sorted(user_info['Major'])),
+                'Minor': ', '.join(sorted(user_info.get('Minor', [])))
             },
         )
 


### PR DESCRIPTION
This addresses issue #90. There might be a better way to solve this issue, but this will resolve the formatting for now. Ive tested this and it works in my development environment.

### Changes

- Stores the list of all majors and minors as a comma separated list within the database when a user registers
     - `A, B, C` instead of `[{"S":"A"},{"S":"B"},{"S":"C"}]`
     - Majors are sorted alphabetically before being combined to make requests of the same set of major/minor deterministic
     - This has been resolved on the backend now, instead of the frontend. I prefer to send a list of majors from the frontend as the schema looks cleaner that way.


