### PR TITLE
Made Minor an optional field and updated tests

### DIFF
--- a/cdk/visit/lambda_code/register_user/register_user.py
+++ b/cdk/visit/lambda_code/register_user/register_user.py
@@ -41,7 +41,7 @@ class RegisterUserFunction():
                 'DOB': user_info['DOB'],
                 'Grad_date': user_info['Grad_Date'],
                 'Major': user_info['Major'],
-                'Minor': user_info['Minor']
+                'Minor': user_info.get('Minor', [])
             },
         )
 

--- a/cdk/visit/lambda_code/test_register_user.py
+++ b/cdk/visit/lambda_code/test_register_user.py
@@ -14,8 +14,8 @@ test_register_user = {"body": json.dumps({
     "Gender": "Male",
     "DOB": "01/02/2002",
     "Grad_Date": "05/01/2023",
-    "Major": "Mathematical Sciences",
-    "Minor": "Business Administration"
+    "Major": ["Mathematical Sciences"],
+    "Minor": ["Business Administration"]
 })}
 
 


### PR DESCRIPTION
This is another bug I introduced when rewriting the form stuff early on (I keep making assumptions about the contract). When a minor is not provided to the frontend form I no longer send a list to the backend, where as it would send an empty list before. This caused the backend to error out.

The fix this PR introduces makes that field actually optional, on both the frontend-->backend and the backend itself. I also updated the test case for registering to match the old contract we decided on a few weeks ago (lists from frontend, instead of csv string).


