### PR TITLE
Revert visits table SK type and make new table for swapping

### DIFF
--- a/cdk/database/__init__.py
+++ b/cdk/database/__init__.py
@@ -11,6 +11,8 @@ class Database(core.Stack):
         self.id = f'Database-{stage}'
         self.users_id = f'Database-users-{stage}'
         self.visits_id = f'Database-visits-{stage}'
+        self.new_visits_id = 'visits'
+
         super().__init__(
             scope, self.id, env=env, termination_protection=True)
 
@@ -71,6 +73,19 @@ class Database(core.Stack):
     def dynamodb_visits_table(self):
         self.visits_table = aws_dynamodb.Table(self,
                                                self.visits_id,
+                                               point_in_time_recovery=True,
+                                               removal_policy=core.RemovalPolicy.RETAIN,
+                                               partition_key=aws_dynamodb.Attribute(
+                                                   name='username',
+                                                   type=aws_dynamodb.AttributeType.STRING),
+                                               sort_key=aws_dynamodb.Attribute(
+                                                   name='visit_time',
+                                                   type=aws_dynamodb.AttributeType.STRING))
+
+        #! new table used to swap the type of the sk, as the
+        #! visitor stack is dependent on this database stack
+        self.new_visits_table = aws_dynamodb.Table(self,
+                                               self.new_visits_id,
                                                point_in_time_recovery=True,
                                                removal_policy=core.RemovalPolicy.RETAIN,
                                                partition_key=aws_dynamodb.Attribute(


### PR DESCRIPTION
This PR makes a new table with the updated SK type as the in-place table type swap failed. So there will be a follow up PR to swap which table the lambda is using, and then to delete the old one.