### PR TITLE
Remove the old visits table

### DIFF
--- a/cdk/database/__init__.py
+++ b/cdk/database/__init__.py
@@ -12,7 +12,7 @@ class Database(core.Stack):
         # todo: remove the stage out of the id string, cloudformation already prefixes all dependancies with the stack that its part of and that contains the stack stage
         self.id = f'Database-{stage}'
         self.users_id = f'Database-users-{stage}'
-        self.old_visits_id = f'Database-visits-{stage}' #! remove in next pr
+        
         self.visits_id = 'visits'
         
         super().__init__(
@@ -73,24 +73,6 @@ class Database(core.Stack):
                                                      type=aws_dynamodb.AttributeType.STRING))
 
     def dynamodb_visits_table(self):
-
-        #! remove in next pr
-        self.old_visits_table = aws_dynamodb.Table(self,
-                                               self.old_visits_id,
-                                               point_in_time_recovery=True,
-                                               removal_policy=core.RemovalPolicy.RETAIN,
-                                               partition_key=aws_dynamodb.Attribute(
-                                                   name='username',
-                                                   type=aws_dynamodb.AttributeType.STRING),
-                                               sort_key=aws_dynamodb.Attribute(
-                                                   name='visit_time',
-                                                   type=aws_dynamodb.AttributeType.STRING))
-       
-        #! remove in next pr
-        self.export_value(self.old_visits_table.table_name)
-        self.export_value(self.old_visits_table.table_arn)
-
-
         self.visits_table = aws_dynamodb.Table(self,
                                                self.visits_id,
                                                point_in_time_recovery=True,

--- a/cdk/makerspace.py
+++ b/cdk/makerspace.py
@@ -38,15 +38,14 @@ class MakerspaceStack(core.Stack):
 
         self.visitors_stack()
 
-        self.database.original_table.grant_read_write_data(
+        self.database.old_table.grant_read_write_data(
             self.visit.lambda_visit)
-        self.database.original_table.grant_write_data(
+        self.database.old_table.grant_write_data(
             self.visit.lambda_register)
 
         self.database.visits_table.grant_read_write_data(
-            self.visit.lambda_visit) #! remove in next pr
-        self.database.new_visits_table.grant_read_write_data(
             self.visit.lambda_visit)
+
         self.database.users_table.grant_read_data(self.visit.lambda_visit)
         self.database.users_table.grant_read_write_data(
             self.visit.lambda_register)
@@ -67,9 +66,9 @@ class MakerspaceStack(core.Stack):
         self.visit = Visit(
             self.app,
             self.stage,
-            self.database.original_table.table_name,
+            self.database.old_table.table_name,
             self.database.users_table.table_name,
-            self.database.new_visits_table.table_name,
+            self.database.visits_table.table_name,
             create_dns=self.create_dns,
             zones=self.dns,
             env=self.env)


### PR DESCRIPTION
This removes the old visits table, which had the SK as a string instead of a number for the visit time.

### Blockers
- [x] Merge #110 first
- [ ] Transition #110 into Prod from Beta