### PR TITLE
refactor(cdk/visit/lambda_code): remove read dependency on old database

### DIFF
--- a/cdk/visit/lambda_code/log_visit/log_visit.py
+++ b/cdk/visit/lambda_code/log_visit/log_visit.py
@@ -58,10 +58,10 @@ class LogVisitFunction():
         """
         true if the user has registered
         """
-        original_table_response = self.original.query(
-            KeyConditionExpression=Key('PK').eq(current_user)
+        user_table_response = self.users.query(
+            KeyConditionExpression=Key('username').eq(current_user)
         )
-        return original_table_response['Count'] != 0
+        return user_table_response['Count'] != 0
 
     # This code was written following the example from:
     # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-using-sdk-python.html


### PR DESCRIPTION
for checking if user was registered.

Problem:

Current lambda code checks the old DynamoDB table (Database using PK and SK) to see if a user has already registered. This adds a dependency on the old table for our registration workflow in the log_visit.py file. We can get rid of this read dependency to potentially remove dual-writing system in the future.

Solution:

In log_visit.py, changed the isUserRegistered function. The query now checks the username column of new "users" table. Previously, the original "old" table's "PK" column was queried. This change checks if the users table has the requested username of the visit.

Testing:

Logs in Dev environment lambda visit function showed that this change was
checking the new users table. Tables updated correctly for completely new
usernames and existing usernames, so no functional difference.

Issue:

N/A, no open GitHub Issue.