### PR TITLE
fix(cdk/visit/lambda_code): fix issue where register lambda does not

### DIFF
--- a/cdk/visit/lambda_code/register_user/register_user.py
+++ b/cdk/visit/lambda_code/register_user/register_user.py
@@ -99,42 +99,30 @@ class RegisterUserFunction():
 
         timestamp = int(time.time())
 
+        # dict for entry into the users table
+        user_table_item = {
+            'username': {'S': user_info['username']},
+            'register_time': {'N': str(timestamp)},
+            'first_name': {'S': user_info['firstName']},
+            'last_name': {'S': user_info['lastName']},
+            'gender': {'S': user_info['Gender']},
+            'date_of_birth': {'S': user_info['DOB']},
+            'position': {'S': user_info['UserPosition']},
+            'grad_semester': {'S': grad_sem},
+            'grad_year': {'S': grad_year},
+            'majors': {'L': majors},
+            'minors': {'L': minors},
+        }
+
         # if the json is from a test request it will have this ttl attribute
         if "last_updated" in user_info:
-            user_table_response = self.dynamodbclient.put_item(
-                TableName=self.USERS_TABLE_NAME,
-                Item={
-                    'username': {'S': user_info['username']},
-                    'register_time': {'N': str(timestamp)},
-                    'first_name': {'S': user_info['firstName']},
-                    'last_name': {'S': user_info['lastName']},
-                    'gender': {'S': user_info['Gender']},
-                    'date_of_birth': {'S': user_info['DOB']},
-                    'position': {'S': user_info['UserPosition']},
-                    'grad_semester': {'S': grad_sem},
-                    'grad_year': {'S': grad_year},
-                    'majors': {'L': majors},
-                    'minors': {'L': minors},
-                    'last_updated':{"N":str(user_info['last_updated'])},   # get last_updated from test users, will set empty field for non-test users
-                })
+            user_table_item['last_updated'] = {"N":str(user_info['last_updated'])}
 
-        # non-testing requests, will not set last_updated attribute
-        else:
-            user_table_response = self.dynamodbclient.put_item(
-                TableName=self.USERS_TABLE_NAME,
-                Item={
-                    'username': {'S': user_info['username']},
-                    'register_time': {'N': str(timestamp)},
-                    'first_name': {'S': user_info['firstName']},
-                    'last_name': {'S': user_info['lastName']},
-                    'gender': {'S': user_info['Gender']},
-                    'date_of_birth': {'S': user_info['DOB']},
-                    'position': {'S': user_info['UserPosition']},
-                    'grad_semester': {'S': grad_sem},
-                    'grad_year': {'S': grad_year},
-                    'majors': {'L': majors},
-                    'minors': {'L': minors},
-                })
+        user_table_response = self.dynamodbclient.put_item(
+            TableName=self.USERS_TABLE_NAME,
+            Item=user_table_item
+            )
+
 
 
         if original_response['ResponseMetadata']['HTTPStatusCode'] != user_table_response['ResponseMetadata']['HTTPStatusCode']:

--- a/cdk/visit/lambda_code/register_user/register_user.py
+++ b/cdk/visit/lambda_code/register_user/register_user.py
@@ -99,24 +99,43 @@ class RegisterUserFunction():
 
         timestamp = int(time.time())
 
-        user_table_response = self.dynamodbclient.put_item(
-            TableName=self.USERS_TABLE_NAME,
-            Item={
-                'username': {'S': user_info['username']},
-                'register_time': {'N': str(timestamp)},
-                'first_name': {'S': user_info['firstName']},
-                'last_name': {'S': user_info['lastName']},
-                'gender': {'S': user_info['Gender']},
-                'date_of_birth': {'S': user_info['DOB']},
-                'position': {'S': user_info['UserPosition']},
-                'grad_semester': {'S': grad_sem},
-                'grad_year': {'S': grad_year},
-                'majors': {'L': majors},
-                'minors': {'L': minors},
-                'last_updated':{"N":str(user_info.get('last_updated',''))},   # get last_updated from test users, set empty field for non-test users
+        # if the json is from a test request it will have this ttl attribute
+        if "last_updated" in user_info:
+            user_table_response = self.dynamodbclient.put_item(
+                TableName=self.USERS_TABLE_NAME,
+                Item={
+                    'username': {'S': user_info['username']},
+                    'register_time': {'N': str(timestamp)},
+                    'first_name': {'S': user_info['firstName']},
+                    'last_name': {'S': user_info['lastName']},
+                    'gender': {'S': user_info['Gender']},
+                    'date_of_birth': {'S': user_info['DOB']},
+                    'position': {'S': user_info['UserPosition']},
+                    'grad_semester': {'S': grad_sem},
+                    'grad_year': {'S': grad_year},
+                    'majors': {'L': majors},
+                    'minors': {'L': minors},
+                    'last_updated':{"N":str(user_info['last_updated'])},   # get last_updated from test users, will set empty field for non-test users
+                })
 
+        # non-testing requests, will not set last_updated attribute
+        else:
+            user_table_response = self.dynamodbclient.put_item(
+                TableName=self.USERS_TABLE_NAME,
+                Item={
+                    'username': {'S': user_info['username']},
+                    'register_time': {'N': str(timestamp)},
+                    'first_name': {'S': user_info['firstName']},
+                    'last_name': {'S': user_info['lastName']},
+                    'gender': {'S': user_info['Gender']},
+                    'date_of_birth': {'S': user_info['DOB']},
+                    'position': {'S': user_info['UserPosition']},
+                    'grad_semester': {'S': grad_sem},
+                    'grad_year': {'S': grad_year},
+                    'majors': {'L': majors},
+                    'minors': {'L': minors},
+                })
 
-            })
 
         if original_response['ResponseMetadata']['HTTPStatusCode'] != user_table_response['ResponseMetadata']['HTTPStatusCode']:
             raise Exception("One of Original Table or User Table update failed.")


### PR DESCRIPTION
update user registrations from website.

Problem:
Certain users have been unable to submit their user registrations from the emailed link. When they click submit, the page does not refresh because the register user lambda fails. Therefore, their user data is not put into the databases. The problem stems from the lambda trying to set the "last_updated" attribute to an empty string ("") for non-test users. However, this is a Number attribute in DynamoDB and cannot be set to an empty string.

Solution:
Changed the RegisterUser Lambda to avoid setting the "last_updated" attribute to an empty string. If the request json has that attribute (i.e. if it is a test request), it will set the attribute. Otherwise, the lambda will put the user info into DynamoDB without setting the "last_updated" attribute. This will allow both test and non-test registrations to pass without lambda errors.

Testing:
The Dev lambda updated with this change did not raise any errors with test or non-test json requests. Also, the dev website had successful registrations that put items into the DynamoDB table without issues.

Issue:
N/A, No open issue.