### PR TITLE
feat(cdk/visit/lambda_code): add print statement for monitoring

### DIFF
--- a/cdk/visit/lambda_code/test_api/test_api.py
+++ b/cdk/visit/lambda_code/test_api/test_api.py
@@ -70,7 +70,7 @@ class TestAPIFunction():
             raise Exception("Visit API Call Failed")
 
         # testing register api endpoint
-        register_data = {
+        register_data_dict = {
             "username": "CANARY_TEST_"+dt_string,
             "firstName": "TEST",
             "lastName": "USER",
@@ -84,12 +84,15 @@ class TestAPIFunction():
             "last_updated":(unix_timestamp_for_ttl)
         }
 
-        register_data = json.dumps(register_data)
+        register_data = json.dumps(register_data_dict)
 
         reg_response = http.request('POST', str(api_url)+"register",body=register_data)
 
         if reg_response.status != 200: 
             raise Exception("Register API Call Failed")
+
+
+        print("Canary Successful at " + str(dt_string) + " for username: " + str(register_data_dict["username"]))
 
 
         return visit_response.status == 200 and reg_response.status== 200 and frontend_response.status==200

--- a/cdk/visit/lambda_code/test_api/test_api.py
+++ b/cdk/visit/lambda_code/test_api/test_api.py
@@ -92,7 +92,7 @@ class TestAPIFunction():
             raise Exception("Register API Call Failed")
 
 
-        print("Canary Successful at " + str(dt_string) + " for username: " + str(register_data_dict["username"]))
+        print("Canary Successful for Canary test with username: " + str(register_data_dict["username"]))
 
 
         return visit_response.status == 200 and reg_response.status== 200 and frontend_response.status==200


### PR DESCRIPTION
Problem:
Successful lambda canary tests do not have any print statements that show up in the Cloudwatch logs for the TestAPI Lambda. It can be difficult to determine which logs contain successful test runs.

Solution:
By adding this print statement, the Cloudwatch logs should display the time and username for any successful tests.

Testing:
By adding this print statement in dev instances, the lambda functionality was not affected.

Issue:
N/A, No open issue.