### PR TITLE
Create new submit quiz architecture

### DIFF
--- a/cdk/api_gateway/__init__.py
+++ b/cdk/api_gateway/__init__.py
@@ -36,7 +36,7 @@ class SharedApiGateway(core.Stack):
     """
 
     def __init__(self, scope: core.Construct, stage: str,
-                 visitors: aws_lambda.Function, register: aws_lambda.Function, *, env: core.Environment, create_dns: bool, zones: MakerspaceDns = None):
+                visitors: aws_lambda.Function, register: aws_lambda.Function, submitQuiz: aws_lambda.Function, *, env: core.Environment, create_dns: bool, zones: MakerspaceDns = None):
 
         super().__init__(scope, f'SharedApiGateway-{stage}', env=env)
 
@@ -47,6 +47,7 @@ class SharedApiGateway(core.Stack):
 
         self.route_visitors(visitors)
         self.route_registration(register)
+        self.route_quiz(submitQuiz)
 
     def create_rest_api(self):
 
@@ -77,3 +78,11 @@ class SharedApiGateway(core.Stack):
         self.register = self.api.root.add_resource('register')
 
         self.register.add_method('POST', register_user)
+    
+    def route_quiz(self, submitQuiz: aws_lambda.Function):
+
+        submit_quiz = aws_apigateway.LambdaIntegration(submitQuiz)
+
+        self.quiz = self.api.root.add_resource('quiz')
+
+        self.quiz.add_method('POST', submit_quiz)

--- a/cdk/api_gateway/__init__.py
+++ b/cdk/api_gateway/__init__.py
@@ -36,7 +36,7 @@ class SharedApiGateway(core.Stack):
     """
 
     def __init__(self, scope: core.Construct, stage: str,
-                visitors: aws_lambda.Function, register: aws_lambda.Function, submitQuiz: aws_lambda.Function, *, env: core.Environment, create_dns: bool, zones: MakerspaceDns = None):
+                visitors: aws_lambda.Function, register: aws_lambda.Function, quiz: aws_lambda.Function, *, env: core.Environment, create_dns: bool, zones: MakerspaceDns = None):
 
         super().__init__(scope, f'SharedApiGateway-{stage}', env=env)
 
@@ -47,7 +47,7 @@ class SharedApiGateway(core.Stack):
 
         self.route_visitors(visitors)
         self.route_registration(register)
-        self.route_quiz(submitQuiz)
+        self.route_quiz(quiz)
 
     def create_rest_api(self):
 
@@ -79,10 +79,10 @@ class SharedApiGateway(core.Stack):
 
         self.register.add_method('POST', register_user)
     
-    def route_quiz(self, submitQuiz: aws_lambda.Function):
+    def route_quiz(self, quiz: aws_lambda.Function):
 
-        submit_quiz = aws_apigateway.LambdaIntegration(submitQuiz)
+        quiz = aws_apigateway.LambdaIntegration(quiz)
 
         self.quiz = self.api.root.add_resource('quiz')
 
-        self.quiz.add_method('POST', submit_quiz)
+        self.quiz.add_method('POST', quiz)

--- a/cdk/database/__init__.py
+++ b/cdk/database/__init__.py
@@ -12,15 +12,19 @@ class Database(core.Stack):
         # todo: remove the stage out of the id string, cloudformation already prefixes all dependancies with the stack that its part of and that contains the stack stage
         self.id = f'Database-{stage}'
         self.users_id = f'Database-users-{stage}'
-        self.old_visits_id = f'Database-visits-{stage}' #! remove in next pr
+        self.old_visits_id = f'Database-visits-{stage}'  # ! remove in next pr
         self.visits_id = 'visits'
-        
+        self.quiz_progress_id = 'quiz_progress'
+        self.quiz_list_id = "quiz_list"
+
         super().__init__(
             scope, self.id, env=env, termination_protection=True)
 
         self.dynamodb_old_table()  # This is the original table
         self.dynamodb_visits_table()
         self.dynamodb_users_table()
+        self.dynamodb_quiz_progress_table()
+        self.dynamodb_quiz_list_table()
 
     def dynamodb_old_table(self):
         """
@@ -118,3 +122,49 @@ class Database(core.Stack):
                                                   type=aws_dynamodb.AttributeType.STRING),
                                               billing_mode=aws_dynamodb.BillingMode.PAY_PER_REQUEST,
                                               time_to_live_attribute="last_updated")
+
+    def dynamodb_quiz_progress_table(self):
+        """
+        This table will hold all users quiz progression.
+
+        Reason for using 2 tables for quiz data (quiz progression and quiz_list): 
+            - Easier to add new quizzes in the future
+            - Makes retrieving all quiz data for a user easier
+
+        schema:
+        - PK = clemson-username
+        - SK = quiz_id
+
+        """
+        self.quiz_progress_table = aws_dynamodb.Table(self,
+                                                      self.quiz_progress_id,
+                                                      point_in_time_recovery=True,
+                                                      removal_policy=core.RemovalPolicy.RETAIN,
+                                                      partition_key=aws_dynamodb.Attribute(
+                                                          name="username",
+                                                          type=aws_dynamodb.AttributeType.STRING
+                                                      ),
+                                                      sort_key=aws_dynamodb.Attribute(
+                                                          name="quiz_id",
+                                                          type=aws_dynamodb.AttributeType.STRING
+                                                      ),
+                                                      billing_mode=aws_dynamodb.BillingMode.PAY_PER_REQUEST,
+                                                      time_to_live_attribute="last_updated")
+
+    def dynamodb_quiz_list_table(self):
+        """
+        This table will hold all quizzes used by the makerspace by quiz_id
+
+        schema:
+        - PK = quiz_id
+        """
+        self.quiz_list_table = aws_dynamodb.Table(self,
+                                                  self.quiz_list_id,
+                                                  point_in_time_recovery=True,
+                                                  removal_policy=core.RemovalPolicy.RETAIN,
+                                                  partition_key=aws_dynamodb.Attribute(
+                                                      name="quiz_id",
+                                                      type=aws_dynamodb.AttributeType.STRING
+                                                  ),
+                                                  billing_mode=aws_dynamodb.BillingMode.PAY_PER_REQUEST,
+                                                  time_to_live_attribute="last_updated")

--- a/cdk/makerspace.py
+++ b/cdk/makerspace.py
@@ -51,9 +51,9 @@ class MakerspaceStack(core.Stack):
             self.visit.lambda_register)
         
         self.database.quiz_list_table.grant_read_write_data(
-            self.visit.lambda_quiz_submit)
+            self.visit.lambda_quiz)
         self.database.quiz_progress_table.grant_read_write_data(
-            self.visit.lambda_quiz_submit)
+            self.visit.lambda_quiz)
 
         self.shared_api_gateway()
 
@@ -85,7 +85,7 @@ class MakerspaceStack(core.Stack):
     def shared_api_gateway(self):
 
         self.api_gateway = SharedApiGateway(
-            self.app, self.stage, self.visit.lambda_visit, self.visit.lambda_register, self.visit.lambda_quiz_submit, env=self.env, zones=self.dns, create_dns=self.create_dns)
+            self.app, self.stage, self.visit.lambda_visit, self.visit.lambda_register, self.visit.lambda_quiz, env=self.env, zones=self.dns, create_dns=self.create_dns)
 
         self.add_dependency(self.api_gateway)
 

--- a/cdk/makerspace.py
+++ b/cdk/makerspace.py
@@ -49,6 +49,11 @@ class MakerspaceStack(core.Stack):
         self.database.users_table.grant_read_data(self.visit.lambda_visit)
         self.database.users_table.grant_read_write_data(
             self.visit.lambda_register)
+        
+        self.database.quiz_list_table.grant_read_write_data(
+            self.visit.lambda_quiz_submit)
+        self.database.quiz_progress_table.grant_read_write_data(
+            self.visit.lambda_quiz_submit)
 
         self.shared_api_gateway()
 
@@ -69,6 +74,8 @@ class MakerspaceStack(core.Stack):
             self.database.old_table.table_name,
             self.database.users_table.table_name,
             self.database.visits_table.table_name,
+            self.database.quiz_list_table.table_name,
+            self.database.quiz_progress_table.table_name,
             create_dns=self.create_dns,
             zones=self.dns,
             env=self.env)
@@ -78,7 +85,7 @@ class MakerspaceStack(core.Stack):
     def shared_api_gateway(self):
 
         self.api_gateway = SharedApiGateway(
-            self.app, self.stage, self.visit.lambda_visit, self.visit.lambda_register, env=self.env, zones=self.dns, create_dns=self.create_dns)
+            self.app, self.stage, self.visit.lambda_visit, self.visit.lambda_register, self.visit.lambda_quiz_submit, env=self.env, zones=self.dns, create_dns=self.create_dns)
 
         self.add_dependency(self.api_gateway)
 

--- a/cdk/visit/__init__.py
+++ b/cdk/visit/__init__.py
@@ -61,7 +61,7 @@ class Visit(core.Stack):
             original_table_name, visits_table_name, users_table_name, ("https://" + self.domain_name))
         self.register_user_lambda(
             original_table_name, users_table_name, ("https://" + self.domain_name))
-        self.submit_quiz_lambda(
+        self.quiz_lambda(
             quiz_list_table_name, quiz_progress_table_name, ("https://" + self.domain_name))
         self.test_api_lambda(env=stage)
 
@@ -150,19 +150,19 @@ class Visit(core.Stack):
             handler='register_user.handler',
             runtime=aws_lambda.Runtime.PYTHON_3_9)
         
-    def submit_quiz_lambda(self, quiz_list_table_name: str, quiz_progress_table_name: str, domain_name: str):
+    def quiz_lambda(self, quiz_list_table_name: str, quiz_progress_table_name: str, domain_name: str):
 
-        self.lambda_quiz_submit = aws_lambda.Function(
+        self.lambda_quiz = aws_lambda.Function(
             self,
-            'RegisterSubmitQuizLambda',
+            'QuizLambda',
             function_name=core.PhysicalName.GENERATE_IF_NEEDED,
-            code=aws_lambda.Code.from_asset('visit/lambda_code/submit_quiz'),
+            code=aws_lambda.Code.from_asset('visit/lambda_code/quiz'),
             environment={
                 'DOMAIN_NAME': domain_name,
                 'QUIZ_LIST_TABLE_NAME': quiz_list_table_name,
                 'QUIZ_PROGRESS_TABLE_NAME': quiz_progress_table_name
             },
-            handler='submit_quiz.handler',
+            handler='quiz.handler',
             runtime=aws_lambda.Runtime.PYTHON_3_9)
         
     def test_api_lambda(self, env: str):

--- a/cdk/visit/__init__.py
+++ b/cdk/visit/__init__.py
@@ -35,6 +35,8 @@ class Visit(core.Stack):
                  original_table_name: str,
                  users_table_name: str,
                  visits_table_name: str,
+                 quiz_list_table_name: str,
+                 quiz_progress_table_name: str,
                  *,
                  env: core.Environment,
                  create_dns: bool,
@@ -59,6 +61,8 @@ class Visit(core.Stack):
             original_table_name, visits_table_name, users_table_name, ("https://" + self.domain_name))
         self.register_user_lambda(
             original_table_name, users_table_name, ("https://" + self.domain_name))
+        self.submit_quiz_lambda(
+            quiz_list_table_name, quiz_progress_table_name, ("https://" + self.domain_name))
         self.test_api_lambda(env=stage)
 
         
@@ -144,6 +148,21 @@ class Visit(core.Stack):
                 'USERS_TABLE_NAME': users_table_name
             },
             handler='register_user.handler',
+            runtime=aws_lambda.Runtime.PYTHON_3_9)
+        
+    def submit_quiz_lambda(self, quiz_list_table_name: str, quiz_progress_table_name: str, domain_name: str):
+
+        self.lambda_quiz_submit = aws_lambda.Function(
+            self,
+            'RegisterSubmitQuizLambda',
+            function_name=core.PhysicalName.GENERATE_IF_NEEDED,
+            code=aws_lambda.Code.from_asset('visit/lambda_code/submit_quiz'),
+            environment={
+                'DOMAIN_NAME': domain_name,
+                'QUIZ_LIST_TABLE_NAME': quiz_list_table_name,
+                'QUIZ_PROGRESS_TABLE_NAME': quiz_progress_table_name
+            },
+            handler='submit_quiz.handler',
             runtime=aws_lambda.Runtime.PYTHON_3_9)
         
     def test_api_lambda(self, env: str):

--- a/cdk/visit/lambda_code/quiz/quiz.py
+++ b/cdk/visit/lambda_code/quiz/quiz.py
@@ -6,7 +6,7 @@ import time
 from typing import Tuple
 
 
-class SubmitQuizFunction():
+class QuizFunction():
     """
     This class wraps the function of the lambda so we can more easily test
     it with moto. In production, we will continue to pass the stood-up
@@ -46,7 +46,7 @@ class SubmitQuizFunction():
 
         return None
 
-    def handle_submit_quiz_request(self, request, context):
+    def handle_quiz_request(self, request, context):
         HEADERS = {
             'Content-Type': 'application/json',
             'Access-Control-Allow-Headers': 'Content-Type',
@@ -73,12 +73,12 @@ class SubmitQuizFunction():
         }
 
 
-submit_quiz_function = SubmitQuizFunction(None, None, None)
+quiz_function = QuizFunction(None, None, None)
 
 
 def handler(request, context):
     # Register quiz information from the makerspace/register console
     # Since this will be hit in prod, it will go ahead and hit our prod
     # dynamodb table
-    return submit_quiz_function.handle_submit_quiz_request(
+    return quiz_function.handle_quiz_request(
         request, context)

--- a/cdk/visit/lambda_code/submit_quiz/submit_quiz.py
+++ b/cdk/visit/lambda_code/submit_quiz/submit_quiz.py
@@ -1,0 +1,84 @@
+import json
+import boto3
+from boto3.dynamodb.conditions import Key
+import os
+import time
+from typing import Tuple
+
+
+class SubmitQuizFunction():
+    """
+    This class wraps the function of the lambda so we can more easily test
+    it with moto. In production, we will continue to pass the stood-up
+    dynamodb table to the handler itself. However, when initializing this class,
+    we can choose to instead initialize it with a mocked version of the
+    dynamodb table.
+    """
+
+    def __init__(self, quiz_list_table, quiz_progress_table, dynamodbclient):
+        if dynamodbclient is None:
+            self.dynamodbclient = boto3.client('dynamodb')
+        else:
+            self.dynamodbclient = dynamodbclient
+
+        self.QUIZ_LIST_TABLE_NAME = os.environ["QUIZ_LIST_TABLE_NAME"]
+        if quiz_list_table is None:
+            dynamodbresource = boto3.resource('dynamodb')
+            self.users = dynamodbresource.Table(self.QUIZ_LIST_TABLE_NAME)
+        else:
+            self.quiz_list = quiz_list_table
+
+        self.QUIZ_PROGRESS_TABLE_NAME = os.environ["QUIZ_PROGRESS_TABLE_NAME"]
+        if quiz_progress_table is None:
+            dynamodbresource = boto3.resource('dynamodb')
+            self.users = dynamodbresource.Table(self.QUIZ_PROGRESS_TABLE_NAME)
+        else:
+            self.quiz_progress = quiz_progress_table
+
+    def add_quiz_info(self, quiz_info):
+        """
+            Steps for adding quiz info to db:
+                1. Check if quiz_id exist in quiz_list
+                    - if not -> add quiz_id to quiz_list
+                2. Format incoming data for db
+                3. Insert quiz_info into quiz_progress_table
+        """
+
+        return None
+
+    def handle_submit_quiz_request(self, request, context):
+        HEADERS = {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Headers': 'Content-Type',
+            'Access-Control-Allow-Origin': os.environ["DOMAIN_NAME"],
+            'Access-Control-Allow-Methods': 'OPTIONS,POST,GET'
+        }
+        if (request is None):
+            return {
+                'headers': HEADERS,
+                'statusCode': 400,
+                'body': json.dumps({
+                    "Message": "Failed to provide parameters"
+                })
+            }
+
+        # Get all of the user information from the json file
+        quiz_info = json.loads(request["body"])
+        # Call Function
+        response = self.add_quiz_info(quiz_info)
+        # Send response
+        return {
+            'headers': HEADERS,
+            'statusCode': response
+        }
+
+
+submit_quiz_function = SubmitQuizFunction(None, None, None)
+
+
+def handler(request, context):
+    # Register quiz information from the makerspace/register console
+    # Since this will be hit in prod, it will go ahead and hit our prod
+    # dynamodb table
+    return submit_quiz_function.handle_submit_quiz_request(
+        request, context)


### PR DESCRIPTION
This will create new aws architecture needed for users to submit quizzes and store that data in aws

Additions:

2 new tables
**quiz_list**: will hold a list of all quizzes by quiz_id
- PK = quiz_id

**quiz_progression**: will hold all users quiz progress with a score
- PK = clemson-username
- SK = quiz_id
- timestamp: str
- state: int

New lambda function
**submit_quiz**: will take in post request data and put it in the necessary tables
- I have left out most of the logic for a later pr.

New api gateway path
**/quiz**: will handle a post request and trigger the new lambda function