### PR TITLE
Moved Amplify config setup into useEffect in App component

### DIFF
--- a/site/visitor-console/src/config/getAmplifyConfig.tsx
+++ b/site/visitor-console/src/config/getAmplifyConfig.tsx
@@ -9,17 +9,20 @@ export function getAmplifyConfig(): AmplifyConfig {
   const hostname = window.location.hostname;
 
   if (hostname === "visit.cumaker.space") {
+    console.log("prod env");
     return {
       userPoolId: "us-east-1_TQ9FwRJ44",
       userPoolClientId: "58lututlkaggp6h8tu9oauqp5p",
     };
   } else if (hostname === "beta-visit.cumaker.space") {
+    console.log("beta env");
     return {
       userPoolId: "us-east-1_FXu4qDv8B",
       userPoolClientId: "5rcrlv4el312ht5gos31v0u0n6",
     };
   } else {
     // Default to production
+    console.log("default env");
     return {
       userPoolId: "us-east-1_TQ9FwRJ44",
       userPoolClientId: "58lututlkaggp6h8tu9oauqp5p",

--- a/site/visitor-console/src/pages/App.tsx
+++ b/site/visitor-console/src/pages/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
 import { Amplify } from "aws-amplify";
 import { locations } from "../library/constants";
 import { getAmplifyConfig } from "../config/getAmplifyConfig";
+import React, { useEffect } from "react";
 
 import LocationSelection from "./LocationSelection";
 import Registration from "./Registration";
@@ -12,20 +13,18 @@ import VisitForm from "../components/VisitForm";
 import Admin from "./Admin";
 import Quizzes from "./QuizStatus";
 
-const config = getAmplifyConfig();
-
-Amplify.configure({
-  Auth: {
-    Cognito: {
-      //  Amazon Cognito User Pool ID
-      userPoolId: config.userPoolId,
-      // Amazon Cognito Web Client ID
-      userPoolClientId: config.userPoolClientId,
-    },
-  },
-});
-
 const App = () => {
+  useEffect(() => {
+    const config = getAmplifyConfig();
+    Amplify.configure({
+      Auth: {
+        Cognito: {
+          userPoolId: config.userPoolId,
+          userPoolClientId: config.userPoolClientId,
+        },
+      },
+    });
+  }, []);
   return (
     <Router>
       <Routes>


### PR DESCRIPTION
Issue fixed: The 'getAmplifyConfig' function was running before any components were rendered, so during the initial page load, window.location.hostname was not set to either "visit.cumaker.space" or "beta-visit.cumaker.space", causing the default configuration to be used.