### PR TITLE
Add quiz progress sign-in / bugfix

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/python:3.10-bookworm",
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers/features/aws-cli:1": {},
+    "ghcr.io/devcontainers-contrib/features/aws-cdk:2": {},
+    "ghcr.io/devcontainers/features/git-lfs:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+  },
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "pip install -r cdk/requirements.txt && cd site/visitor-console && npm install",
+  // Configure tool-specific properties.
+  "customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "GitHub.vscode-pull-request-github",
+        "ms-python.python"
+      ]
+    }
+  }
+}

--- a/cdk/accounts_config.py
+++ b/cdk/accounts_config.py
@@ -59,8 +59,12 @@ accounts = {
         'account': '684082786745',
         'region': 'us-east-1'
     },
-        'Dev-soll': {
+    'Dev-soll': {
         'account': '104308618712',
+        'region': 'us-east-1'
+    },
+    'Dev-lrboyer': {
+        'account': '744918461173',
         'region': 'us-east-1'
     },
 }

--- a/cdk/requirements.txt
+++ b/cdk/requirements.txt
@@ -89,7 +89,7 @@ pyparsing==3.0.7
 pytest==7.0.1
 python-dateutil==2.8.2
 pytz==2021.3
-PyYAML==5.4
+PyYAML==6.0
 requests==2.27.1
 responses==0.18.0
 rsa==4.7

--- a/site/visitor-console/index.html
+++ b/site/visitor-console/index.html
@@ -11,6 +11,12 @@
     <link rel="manifest" href="/manifest.json" />
 
     <title>Makerspace Sign-in</title>
+
+    <script>
+      if (global === undefined) {
+        var global = window;
+      }
+    </script>
   </head>
   <body style="height: 100%">
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/site/visitor-console/src/components/QuizProgress.tsx
+++ b/site/visitor-console/src/components/QuizProgress.tsx
@@ -1,0 +1,90 @@
+import { useState, useEffect } from "react";
+import { api_endpoint } from "../library/constants";
+import { useSearchParams } from "react-router-dom";
+
+const QuizProgress = () => {
+  const [quizzes, setQuizzes] = useState<
+    {
+      quiz_id: string;
+      state: number;
+    }[]
+  >([]);
+  const [loading, setLoading] = useState(false);
+
+  let [searchParams] = useSearchParams();
+  const username = (searchParams.get("username") as string) || "/";
+
+  useEffect(() => {
+    fetch(`${api_endpoint}/quiz/${username}`)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Network response was not ok");
+        }
+        return response.json();
+      })
+      .then((data) => {
+        setQuizzes(data); // Assuming the response data is an array of quiz objects
+        setLoading(false);
+      })
+      .catch((error) => {
+        console.error("Error fetching data:", error);
+        setLoading(false);
+      });
+  }, []);
+
+  //This cuts the quiz progress into lengthOfTable quiz long objects so that the tables fit on the pagecard
+  const renderTables = () => {
+    const lengthOfTable = 4;
+
+    const numQuizzes = quizzes.length;
+    const numTables = Math.ceil(numQuizzes / lengthOfTable);
+
+    return Array.from({ length: numTables }, (_, index) => {
+      const startIdx = index * lengthOfTable;
+      const endIdx = Math.min((index + 1) * lengthOfTable, numQuizzes);
+      const tableQuizzes = quizzes.slice(startIdx, endIdx);
+
+      return (
+        <div key={index}>
+          <table className="table table-bordered table-primary">
+            <thead>
+              <tr>
+                {tableQuizzes.map((quiz, idx) => (
+                  <th className="text-center align-middle" key={idx}>
+                    {quiz.quiz_id}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                {tableQuizzes.map((quiz, idx) => (
+                  <td
+                    key={idx}
+                    className={
+                      quiz.state === 1
+                        ? "bg-success text-center align-middle" // Passed
+                        : quiz.state === 0
+                        ? "bg-danger text-center align-middle" // Failed
+                        : "text-center align-middle" // Not Attempted
+                    }
+                  >
+                    {quiz.state === 1
+                      ? "Passed"
+                      : quiz.state === 0
+                      ? "Failed"
+                      : "Not Attempted"}
+                  </td>
+                ))}
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      );
+    });
+  };
+
+  return <div>{loading ? <p>Loading...</p> : renderTables()}</div>;
+};
+
+export default QuizProgress;

--- a/site/visitor-console/src/components/VisitForm/index.tsx
+++ b/site/visitor-console/src/components/VisitForm/index.tsx
@@ -46,7 +46,7 @@ const VisitForm = ({ location }: VisitFormProps) => {
     }).then((response) => {
       setLoading(false);
       if (response.ok) {
-        navigate(`/success?next=/${location.slug}`);
+        navigate(`/success?next=/${location.slug}&username=${data.username}`);
       } else {
         navigate(`/error?next=/${location.slug}`);
       }

--- a/site/visitor-console/src/pages/SignInSuccess.tsx
+++ b/site/visitor-console/src/pages/SignInSuccess.tsx
@@ -1,6 +1,7 @@
 import Countdown from "react-countdown";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import PageCard from "../components/PageCard";
+import QuizProgress from "../components/QuizProgress";
 
 const SignInSuccess = () => {
   const navigate = useNavigate();
@@ -8,7 +9,9 @@ const SignInSuccess = () => {
   const next_page = (searchParams.get("next") as string) || "/";
 
   const renderer = () => (
-    <PageCard title="Sign-In Sucessful">
+    <PageCard title="Sign-In Successful">
+      <h1>Your Safety Quiz Progress</h1>
+      <QuizProgress />
       <Link to={next_page} className="btn btn-secondary">
         Continue
       </Link>


### PR DESCRIPTION
Goal: Add quiz progress table on sign in page so users can see their quiz progress after successful sign in (Makerspace staff asked for this new feature)

Solution:
Add new component to sign in page that will fetch quiz progress and display it.

How:
Adds new query parameter on sign in so new component can grab the username 

BUGFIX:
Local hosting was not working due to "global" not being defined, fixed it in vite.config