### PR TITLE
fix: Support dev container on aarch64

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,11 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "image": "mcr.microsoft.com/devcontainers/python:3.10-bookworm",
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
     "ghcr.io/devcontainers/features/aws-cli:1": {},
     "ghcr.io/devcontainers-contrib/features/aws-cdk:2": {},
+    "ghcr.io/devcontainers/features/git-lfs:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
   },
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": "pip install -r cdk/requirements.txt && cd site/visitor-console && npm install",
@@ -13,6 +15,8 @@
     "vscode": {
       // Add the IDs of extensions you want installed when the container is created.
       "extensions": [
+        "dbaeumer.vscode-eslint",
+        "GitHub.vscode-pull-request-github",
         "ms-python.python"
       ]
     }


### PR DESCRIPTION
Problem: The universal base image that Microsoft provides doesn't run on aarch64 CPUs like a Mac M1/2/3 chip.

Solution: Use the python base container & add in some of the extra features we're missing out on.

Testing: Verified that I could launch this dev-container on my mac & in code spaces from my fork.