### PR TITLE
Removed Unsupported Variable

### DIFF
--- a/cdk/visit/__init__.py
+++ b/cdk/visit/__init__.py
@@ -58,10 +58,7 @@ class Visit(core.Stack):
                                                aws_s3_deployment.Source.asset(
                                                    f'visit/console/{self.stage}/')
                                            ],
-                                           destination_bucket=self.bucket,
-                                           custom_resource_provider={
-                                                "lambda_function_runtime": "python3.9"
-                                            })
+                                           destination_bucket=self.bucket)
         
     def cloudfront_distribution(self):
 


### PR DESCRIPTION
As we're using AWS CDK V1, we cannot use the variable custom_resource_provider in the source_bucket() function in visit/__init__.py (accidentally overlooked this small detail)