### PR TITLE
Attempting to fix CloudFront Distro

### DIFF
--- a/cdk/visit/__init__.py
+++ b/cdk/visit/__init__.py
@@ -66,13 +66,13 @@ class Visit(core.Stack):
         if self.create_dns:
             domain_name = self.zones.visit.zone_name
             kwargs['domain_names'] = [domain_name]
-            # kwargs['certificate'] = aws_certificatemanager.DnsValidatedCertificate(
-            #     self, 'VisitorsCertificate', domain_name=domain_name, hosted_zone=self.zones.visit)
-            kwargs['certificate'] = aws_certificatemanager.Certificate(
-                self, 'VisitorsCertificate',
-                domain_name=domain_name,
-                validation=aws_certificatemanager.CertificateValidation.from_dns(self.zones.visit)
-            )
+            kwargs['certificate'] = aws_certificatemanager.DnsValidatedCertificate(
+                self, 'VisitorsCertificate', domain_name=domain_name, hosted_zone=self.zones.visit)
+            # kwargs['certificate'] = aws_certificatemanager.Certificate(
+            #     self, 'VisitorsCertificate',
+            #     domain_name=domain_name,
+            #     validation=aws_certificatemanager.CertificateValidation.from_dns(self.zones.visit)
+            # )
 
         kwargs['default_behavior'] = aws_cloudfront.BehaviorOptions(
             origin=aws_cloudfront_origins.S3Origin(


### PR DESCRIPTION
There is an error when running the Pipeline:

Resource handler returned message: "Invalid request provided: AWS::CloudFront::Distribution: One or more of the CNAMEs you provided are already associated with a different resource. (Service: CloudFront, Status Code: 409)"

Attempting to fix the code by using an already associated CNAME record that is associated with the CloudFront Distro that is already made. If I receive the runtime error again, then whichever functions/etc. that are tied with the CNAME record are outdated and will have to find a solution for that. Or, recreate the CNAME record with the correct information via the Pipeline. 