### PR TITLE
Changes in cdk.json

### DIFF
--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -6,6 +6,7 @@
     "@aws-cdk/core:newStyleStackSynthesis": true,
     "@aws-cdk/core:stackRelativeExports": "true",
     "@aws-cdk/aws-certificatemanager:defaultDnsValidatedCertificateFunctionRuntime": "nodejs18.x",
-    "@aws-cdk/aws-s3-deployment:defaultBucketDeploymentFunctionRuntime": "python3.9"
+    "@aws-cdk/aws-s3-deployment:defaultBucketDeploymentFunctionRuntime": "python3.9",
+    "@aws-cdk/aws-s3-deployment:lambdaFunctionRuntime": "python3.9"
   }
 }


### PR DESCRIPTION
Needed to make the lambdaFunctionRuntime be set to python 3.9. What has been creating the runtime issues (from what I understand) is that the aws_s3_deployment.BucketDeployment function automatically creates a Lambda function required for our environment in its construct backend and the default runtime is python 3.7. However, python 3.7 is no longer supported and the change in cdk.json *should* set the default runtime for the construct's Lambda function to python 3.9.