### PR TITLE
Changed how self.api is made in SharedAPIGateway

### DIFF
--- a/cdk/api_gateway/shared_api_gateway.py
+++ b/cdk/api_gateway/shared_api_gateway.py
@@ -85,7 +85,8 @@ class SharedApiGateway(Stack):
     def create_rest_api(self):
 
         # Create the Rest API
-        self.api = aws_apigateway.RestApi(self, 'SharedApiGateway')
+        self.api = aws_apigateway.RestApi(self, 'SharedApiGateway',
+                                          domain_name=self.zones.api.zone_name)
 
         # Handle dns integration
         if self.create_dns:
@@ -105,7 +106,7 @@ class SharedApiGateway(Stack):
             #                          certificate=certificate)
             
             # Add a domain name to the API
-            self.api.domain_name = aws_apigateway.DomainName(
+            self.api_domain_name = aws_apigateway.DomainName(
                 self,
                 "ExistingApiDomainName",
                 domain_name=domain_name,
@@ -125,7 +126,7 @@ class SharedApiGateway(Stack):
             aws_apigateway.BasePathMapping(
                 self,
                 "BasePathMapping",
-                domain_name=self.api.domain_name,
+                domain_name=self.api_domain_name,
                 rest_api=self.api,
             )
 


### PR DESCRIPTION
Had to add a domain_name attribute to self.api as it wasn't being reference correctly in dns/__init__.py and causing an error when building the pipeline. 