### PR TITLE
Removed BasePathMapping

### DIFF
--- a/cdk/api_gateway/shared_api_gateway.py
+++ b/cdk/api_gateway/shared_api_gateway.py
@@ -131,12 +131,12 @@ class SharedApiGateway(Stack):
             )
             
             # Associate the existing domain with the new Rest API using BasePathMapping
-            aws_apigateway.BasePathMapping(
-                self,
-                "BasePathMapping",
-                domain_name=self.api_domain_name,
-                rest_api=self.api,
-            )
+            # aws_apigateway.BasePathMapping(
+            #     self,
+            #     "BasePathMapping",
+            #     domain_name=self.api_domain_name,
+            #     rest_api=self.api,
+            # )
 
 
     def deploy_api_stage(self, stage_name: str = "prod"):


### PR DESCRIPTION
Had BasePathMapping in SharedAPIGateway stack to allow the referenced domain name to be associated with the new API being creating in the stack. Trying to remove this to see if we do not need to remap the variable for things to work as we're running into an error with having it included.