### PR TITLE
Resorted back to old code

### DIFF
--- a/cdk/api_gateway/shared_api_gateway.py
+++ b/cdk/api_gateway/shared_api_gateway.py
@@ -85,59 +85,18 @@ class SharedApiGateway(Stack):
     def create_rest_api(self):
 
         # Create the Rest API
-        # self.api = aws_apigateway.RestApi(self, 'SharedApiGateway')
-        self.api = aws_apigateway.RestApi(
-            self,
-            "SharedApiGateway",
-            # domain_name=aws_apigateway.DomainNameOptions(
-            #     domain_name=domain_name,
-            #     certificate=certificate,
-            # ),
-        )
+        self.api = aws_apigateway.RestApi(self, 'SharedApiGateway')
 
         # Handle dns integration
         if self.create_dns:
             domain_name = self.zones.api.zone_name
-            # certificate = aws_certificatemanager.DnsValidatedCertificate(self, 'ApiGatewayCert',
-            #                                                              domain_name=domain_name,
-            #                                                              hosted_zone=self.zones.api)
-            
-            # Reference an existing certificate
-            # existing_certificate_arn = f"arn:aws:acm:{Aws.REGION}:{Aws.ACCOUNT_ID}:certificate/f002de99-9a60-48c4-8744-4a1e18424840"
-            # certificate = aws_certificatemanager.Certificate.from_certificate_arn(
-            #     self, 'ExistingApiCertificate', existing_certificate_arn
-            # )
+            certificate = aws_certificatemanager.DnsValidatedCertificate(self, 'ApiGatewayCert',
+                                                                         domain_name=domain_name,
+                                                                         hosted_zone=self.zones.api)
 
-            # self.api.add_domain_name('ApiGatewayDomainName',
-            #                          domain_name=domain_name,
-            #                          certificate=certificate)
-            
-            # Add a domain name to the API
-            # self.api_domain_name = aws_apigateway.DomainName(
-            #     self,
-            #     "ExistingApiDomainName",
-            #     domain_name=domain_name,
-            #     certificate=certificate
-            # )
-            
-
-            # Reference the existing API Gateway Domain Name
-            self.api_domain_name = aws_apigateway.DomainName.from_domain_name_attributes(
-                self,
-                "ExistingApiDomainName",
-                domain_name=domain_name,
-                domain_name_alias_hosted_zone_id="Z02880721JJ9EMQ8VFEV3",
-                domain_name_alias_target=f"d-6fxcutcsv0.execute-api.{Aws.REGION}.amazonaws.com."
-            )
-            
-            # Associate the existing domain with the new Rest API using BasePathMapping
-            # aws_apigateway.BasePathMapping(
-            #     self,
-            #     "BasePathMapping",
-            #     domain_name=self.api_domain_name,
-            #     rest_api=self.api,
-            # )
-
+            self.api.add_domain_name('ApiGatewayDomainName',
+                                     domain_name=domain_name,
+                                     certificate=certificate)
 
     def deploy_api_stage(self, stage_name: str = "prod"):
         self.stage = aws_apigateway.Stage(

--- a/cdk/dns/__init__.py
+++ b/cdk/dns/__init__.py
@@ -106,19 +106,11 @@ class MakerspaceDnsRecords(Stack):
                                                                   hosted_zone_id=self.zones.api.hosted_zone_id,
                                                                   zone_name=self.zones.api.zone_name)
 
-        # aws_route53.ARecord(self, 'ApiRecord',
-        #                     zone=zone,
-        #                     target=aws_route53.RecordTarget(
-        #                         alias_target=aws_route53_targets.ApiGatewayDomain(
-        #                             api_gateway.domain_name)))
-        
         aws_route53.ARecord(self, 'ApiRecord',
-                    zone=zone,
-                    target=aws_route53.RecordTarget.from_alias(
-                        aws_route53_targets.ApiGatewayDomain(
-                            domain_name=api_gateway.domain_name
-                        )
-                    ))
+                            zone=zone,
+                            target=aws_route53.RecordTarget(
+                                alias_target=aws_route53_targets.ApiGatewayDomain(
+                                    api_gateway.domain_name)))
 
     def visit_record(self, visit: aws_cloudfront.Distribution):
 

--- a/cdk/visit/__init__.py
+++ b/cdk/visit/__init__.py
@@ -69,21 +69,8 @@ class Visit(Stack):
         if self.create_dns:
             domain_name = self.zones.visit.zone_name
             kwargs['domain_names'] = [domain_name]
-            # kwargs['certificate'] = aws_certificatemanager.DnsValidatedCertificate(
-            #     self, 'VisitorsCertificate', domain_name=domain_name, hosted_zone=self.zones.visit)
-            
-            # Create a new CNAME
-            # kwargs['certificate'] = aws_certificatemanager.Certificate(
-            #     self, 'VisitorsCertificate',
-            #     domain_name=domain_name,
-            #     validation=aws_certificatemanager.CertificateValidation.from_dns(self.zones.visit)
-            # )
-            
-            # Obtain certificate from existing certificate
-            existing_certificate_arn = f"arn:aws:acm:{Aws.REGION}:{Aws.ACCOUNT_ID}:certificate/f53fd3eb-7791-407c-9458-50abea7ff9ce"
-            kwargs['certificate'] = aws_certificatemanager.Certificate.from_certificate_arn(
-                self, 'VisitorsCertificate', existing_certificate_arn
-            )
+            kwargs['certificate'] = aws_certificatemanager.DnsValidatedCertificate(
+                self, 'VisitorsCertificate', domain_name=domain_name, hosted_zone=self.zones.visit)
 
         kwargs['default_behavior'] = aws_cloudfront.BehaviorOptions(
             origin=aws_cloudfront_origins.S3Origin(
@@ -105,24 +92,5 @@ class Visit(Stack):
             ttl=Duration.seconds(10)
         )]
 
-        # Creates a new CloudFront Distribution
-        # self.distribution = aws_cloudfront.Distribution(
-        #     self, 'VisitorsConsoleCache', **kwargs)
-        
-        # Reference the existing CloudFront distribution
-        self.distribution = aws_cloudfront.Distribution.from_distribution_attributes(
-            self, 
-            "ExistingCloudFrontDistribution",
-            distribution_id="E1RWW3RYQYP7C",  # Replace with your CloudFront Distribution ID
-            domain_name="d3jh19seg4qmka.cloudfront.net" 
-        )
-         
-        # Create a Route 53 alias record pointing to the distribution
-        # if self.create_dns:
-        #     aws_route53.ARecord(
-        #         self, 'VisitorsAliasRecord',
-        #         zone=self.zones.visit,  # Your Route 53 hosted zone
-        #         target=aws_route53.RecordTarget.from_alias(
-        #             aws_route53.CloudFrontTarget(self.distribution)
-        #         )
-        #     )
+        self.distribution = aws_cloudfront.Distribution(
+            self, 'VisitorsConsoleCache', **kwargs)


### PR DESCRIPTION
Ended up removing the old stacks that were no longer needed as they were causing conflicting CNAME record errors, as the old stacks were utilizing the resources we needed to create. Therefore, the old code would build the environment as intended and build the resources required for the envionment to operate.