### PR TITLE
Moved create_rest_api() and Removed Depreciated Resources

### DIFF
--- a/cdk/api_gateway/shared_api_gateway.py
+++ b/cdk/api_gateway/shared_api_gateway.py
@@ -39,15 +39,16 @@ class SharedApiGateway(Stack):
     def __init__(self, scope: Construct, stage: str,
                 user: aws_lambda.Function, visits: aws_lambda.Function,
                  qualifications: aws_lambda.Function, equipment: aws_lambda.Function,
-                 *, env: Environment, create_dns: bool, 
+                 api: aws_apigateway.RestApi, *, env: Environment, create_dns: bool, 
                 zones: MakerspaceDns = None):
 
         super().__init__(scope, 'SharedApiGateway', env=env)
 
         self.create_dns = create_dns
         self.zones = zones
+        self.api = api
 
-        self.create_rest_api()
+        # self.create_rest_api()
 
         # Scheme of "..._user_id" indicates routing for endpoints with
         # the path parameter {user_id}
@@ -82,21 +83,21 @@ class SharedApiGateway(Stack):
         self.plan.add_api_key(self.api_key)
 
 
-    def create_rest_api(self):
+    # def create_rest_api(self):
 
-        # Create the Rest API
-        self.api = aws_apigateway.RestApi(self, 'SharedApiGateway')
+    #     # Create the Rest API
+    #     self.api = aws_apigateway.RestApi(self, 'SharedApiGateway')
 
-        # Handle dns integration
-        if self.create_dns:
-            domain_name = self.zones.api.zone_name
-            certificate = aws_certificatemanager.DnsValidatedCertificate(self, 'ApiGatewayCert',
-                                                                         domain_name=domain_name,
-                                                                         hosted_zone=self.zones.api)
+    #     # Handle dns integration
+    #     if self.create_dns:
+    #         domain_name = self.zones.api.zone_name
+    #         certificate = aws_certificatemanager.DnsValidatedCertificate(self, 'ApiGatewayCert',
+    #                                                                      domain_name=domain_name,
+    #                                                                      hosted_zone=self.zones.api)
 
-            self.api.add_domain_name('ApiGatewayDomainName',
-                                     domain_name=domain_name,
-                                     certificate=certificate)
+    #         self.api.add_domain_name('ApiGatewayDomainName',
+    #                                  domain_name=domain_name,
+    #                                  certificate=certificate)
 
     def deploy_api_stage(self, stage_name: str = "prod"):
         self.stage = aws_apigateway.Stage(

--- a/cdk/makerspace.py
+++ b/cdk/makerspace.py
@@ -123,6 +123,7 @@ class MakerspaceStack(Stack):
             self.backend_api.lambda_visits_handler,
             self.backend_api.lambda_qualifications_handler,
             self.backend_api.lambda_equipment_handler,
+            api=self.dns.api,
             env=self.env, zones=self.dns, create_dns=self.create_dns
         )
 
@@ -130,7 +131,8 @@ class MakerspaceStack(Stack):
 
     def hosted_zones_stack(self):
 
-        self.dns = MakerspaceDns(self.app, self.stage, env=self.env)
+        self.dns = MakerspaceDns(self.app, self.stage, create_dns=self.create_dns, 
+                                 env=self.env)
 
         self.add_dependency(self.dns)
 
@@ -147,7 +149,7 @@ class MakerspaceStack(Stack):
             self.stage,
             env=self.env,
             zones=self.dns,
-            api_gateway=self.api_gateway.api,
+            api_gateway=self.dns.api,
             visit_distribution=self.visit.distribution
         )
 

--- a/cdk/visit/__init__.py
+++ b/cdk/visit/__init__.py
@@ -69,11 +69,12 @@ class Visit(Stack):
         if self.create_dns:
             domain_name = self.zones.visit.zone_name
             kwargs['domain_names'] = [domain_name]
-            kwargs['certificate'] = aws_certificatemanager.DnsValidatedCertificate(
-                self, 'VisitorsCertificate', domain_name=domain_name, hosted_zone=self.zones.visit)
+            kwargs['certificate'] = aws_certificatemanager.Certificate(
+                self, 'VisitorsCertificate', domain_name=domain_name, 
+                validation=aws_certificatemanager.CertificateValidation.from_dns(self.zones.visit))
 
         kwargs['default_behavior'] = aws_cloudfront.BehaviorOptions(
-            origin=aws_cloudfront_origins.S3Origin(
+            origin=aws_cloudfront_origins.S3BucketOrigin(
                 bucket=self.bucket,
                 origin_access_identity=self.oai),
             viewer_protocol_policy=aws_cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS)


### PR DESCRIPTION
Needed to move the function create_rest_api() from api_gateway/shared_api_gateway.py to dns/__init__.py (into the MakerspaceDns class). The reasoning behind it is because MakerspaceDnsRecords class needs to reference the Rest API which used to be created AFTER the function call in makerspace.py. Therefore, now that we have it being created earlier in the process in makerspace.py, we will have the required resources to move forward with deployment and in the correct order. Additionally, I have upgraded some functions to utilize AWS CDK V2 ways of creating the aws_certificatemanager.Certificate certificates (makes more sense if you see it in the code changes).