### PR TITLE
Testing Arrangement of resource creation

### DIFF
--- a/cdk/api_gateway/shared_api_gateway.py
+++ b/cdk/api_gateway/shared_api_gateway.py
@@ -39,16 +39,15 @@ class SharedApiGateway(Stack):
     def __init__(self, scope: Construct, stage: str,
                 user: aws_lambda.Function, visits: aws_lambda.Function,
                  qualifications: aws_lambda.Function, equipment: aws_lambda.Function,
-                 api: aws_apigateway.RestApi, *, env: Environment, create_dns: bool, 
+                 *, env: Environment, create_dns: bool, 
                 zones: MakerspaceDns = None):
 
         super().__init__(scope, 'SharedApiGateway', env=env)
 
         self.create_dns = create_dns
         self.zones = zones
-        self.api = api
 
-        # self.create_rest_api()
+        self.create_rest_api()
 
         # Scheme of "..._user_id" indicates routing for endpoints with
         # the path parameter {user_id}
@@ -83,26 +82,38 @@ class SharedApiGateway(Stack):
         self.plan.add_api_key(self.api_key)
 
 
-    # def create_rest_api(self):
+    def create_rest_api(self):
 
-    #     # Create the Rest API
-    #     self.api = aws_apigateway.RestApi(self, 'SharedApiGateway')
+        # Create the Rest API
+        self.api = aws_apigateway.RestApi(self, 'SharedApiGateway')
 
-    #     # Handle dns integration
-    #     if self.create_dns:
-    #         domain_name = self.zones.api.zone_name
-    #         certificate = aws_certificatemanager.DnsValidatedCertificate(self, 'ApiGatewayCert',
-    #                                                                      domain_name=domain_name,
-    #                                                                      hosted_zone=self.zones.api)
+        # Handle dns integration
+        if self.create_dns:
+            domain_name = self.zones.api_hosted_zone.zone_name
+            # Depreciated way of making certificate
+            # certificate = aws_certificatemanager.DnsValidatedCertificate(self, 'ApiGatewayCert',
+            #                                                              domain_name=self.domains.api,
+            #                                                              hosted_zone=self.api)
 
-    #         self.api.add_domain_name('ApiGatewayDomainName',
-    #                                  domain_name=domain_name,
-    #                                  certificate=certificate)
+            certificate = aws_certificatemanager.Certificate(
+                self, 'ApiGatewayCert',
+                domain_name=domain_name,
+                validation=aws_certificatemanager.CertificateValidation.from_dns(self.zones.api_hosted_zone)
+            )
+
+            self.api.add_domain_name('ApiGatewayDomainName',
+                                     domain_name=domain_name,
+                                     certificate=certificate)
 
     def deploy_api_stage(self, stage_name: str = "prod"):
+        if not self.api.latest_deployment:
+            deployment = aws_apigateway.Deployment(self, 'ApiDeployment', api=self.api)
+        else:
+            deployment = self.api.latest_deployment
+
         self.stage = aws_apigateway.Stage(
             self, id=stage_name,
-            deployment=self.api.latest_deployment,
+            deployment=deployment,
             stage_name=stage_name,
         )
 

--- a/cdk/makerspace.py
+++ b/cdk/makerspace.py
@@ -38,23 +38,23 @@ class MakerspaceStack(Stack):
 
         self.domains = Domains(self.stage)
 
-        self.create_dns = 'dev' not in self.domains.stage
-        
         self.hosted_zones_stack()
+
+        self.create_dns = 'dev' not in self.domains.stage
 
         self.database_stack()
 
         self.visitors_stack()
 
+        self.cognito_setup()
+
         self.backend_stack()
+
+        self.shared_api_gateway()
 
         if self.create_dns:
             self.dns_records_stack()
 
-        self.shared_api_gateway()
-        
-        self.cognito_setup()
-        
         # if self.stage.lower() == 'prod':
         #     self.data_migration_stack()
         
@@ -123,7 +123,6 @@ class MakerspaceStack(Stack):
             self.backend_api.lambda_visits_handler,
             self.backend_api.lambda_qualifications_handler,
             self.backend_api.lambda_equipment_handler,
-            api=self.dns.api,
             env=self.env, zones=self.dns, create_dns=self.create_dns
         )
 
@@ -131,8 +130,7 @@ class MakerspaceStack(Stack):
 
     def hosted_zones_stack(self):
 
-        self.dns = MakerspaceDns(self.app, self.stage, create_dns=self.create_dns, 
-                                 env=self.env)
+        self.dns = MakerspaceDns(self.app, self.stage, env=self.env)
 
         self.add_dependency(self.dns)
 
@@ -149,7 +147,7 @@ class MakerspaceStack(Stack):
             self.stage,
             env=self.env,
             zones=self.dns,
-            api_gateway=self.dns.api,
+            api_gateway=self.api_gateway.api,
             visit_distribution=self.visit.distribution
         )
 


### PR DESCRIPTION
Last pipeline run failed due to an ACM Certificate remaining in the pending validation status and could not figure out why the certificate would not become issued. Therefore, I believe it could be the way the resources are being created and in the order they're being created. I decided to go back to the order of the resources being created prior to the last run. 